### PR TITLE
Feature/refactor admin tools view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+    "typescript.autoClosingTags": false
 }

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense } from 'react';
+import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
 import {
@@ -8,15 +8,21 @@ import {
   Clock,
   Edit3,
   Settings,
-  Loader2,
-  AlertCircle,
+  ClipboardList,
+  DatabaseZap,
 } from 'lucide-react';
+import { Suspense } from 'react'; // Suspense debe importarse desde React
+import { Loader2, AlertCircle } from 'lucide-react'; // Mover íconos a su propia importación
 import { Alert, AlertDescription } from '@/components/ui/alert';
+
+// Importar todos los formularios de herramientas
 import { JustificacionForm } from '@/components/admin/JustificacionForm';
 import { RegistroManualForm } from '@/components/admin/RegistroManualForm';
 import { CorreccionEstatusForm } from '@/components/admin/CorreccionEstatusForm';
+import { CorreccionRegistrosForm } from '@/components/admin/CorreccionRegistrosForm';
+import { ConsolidacionManualForm } from '@/components/admin/ConsolidacionManualForm';
 
-// Componente de carga para las herramientas
+// Componente de carga (sin cambios)
 const LoadingComponent = ({ title }: { title: string }) => (
   <div className='flex items-center justify-center py-12'>
     <div className='text-center space-y-4'>
@@ -26,28 +32,11 @@ const LoadingComponent = ({ title }: { title: string }) => (
   </div>
 );
 
-// Componente de error para las herramientas
-const ErrorComponent = ({ title, error }: { title: string; error: Error }) => (
-  <Alert variant='destructive'>
-    <AlertCircle className='h-4 w-4' />
-    <AlertDescription>
-      <div className='space-y-2'>
-        <div className='font-medium'>Error al cargar {title}</div>
-        <div className='text-sm'>{error.message}</div>
-        <div className='text-xs text-muted-foreground'>
-          Intente recargar la página. Si el problema persiste, contacte al
-          administrador del sistema.
-        </div>
-      </div>
-    </AlertDescription>
-  </Alert>
-);
-
 export default function HerramientasAdminPage() {
   return (
     <div className='p-8'>
       <div className='max-w-7xl mx-auto'>
-        {/* Header with breadcrumbs */}
+        {/* Header (sin cambios) */}
         <header className='mb-8'>
           <BreadcrumbNav
             items={[
@@ -62,15 +51,16 @@ export default function HerramientasAdminPage() {
                 Herramientas Administrativas
               </h1>
               <p className='text-muted-foreground mt-1'>
-                Gestión de justificaciones, registros manuales y corrección de
-                estatus
+                Gestión de justificaciones, registros, asistencias y procesos
+                del sistema.
               </p>
             </div>
           </div>
         </header>
 
-        {/* Tabs Container */}
+        {/* Contenedor de Pestañas Reestructurado */}
         <Tabs defaultValue='justificaciones' className='w-full'>
+          {/* AHORA SOLO 3 PESTAÑAS PRINCIPALES */}
           <TabsList className='grid w-full grid-cols-3 mb-8'>
             <TabsTrigger
               value='justificaciones'
@@ -80,23 +70,23 @@ export default function HerramientasAdminPage() {
               Justificaciones
             </TabsTrigger>
             <TabsTrigger
-              value='registro-manual'
+              value='registros-checadas'
               className='flex items-center gap-2'
             >
               <Clock className='h-4 w-4' />
-              Registro Manual
+              Registros y Checadas
             </TabsTrigger>
             <TabsTrigger
-              value='correccion-estatus'
+              value='asistencias-procesos'
               className='flex items-center gap-2'
             >
-              <Edit3 className='h-4 w-4' />
-              Corrección de Estatus
+              <DatabaseZap className='h-4 w-4' />
+              Asistencias y Procesos
             </TabsTrigger>
           </TabsList>
 
-          {/* Justificaciones Tab */}
-          <TabsContent value='justificaciones' className='space-y-6'>
+          {/* Pestaña 1: Justificaciones (sin cambios internos) */}
+          <TabsContent value='justificaciones'>
             <div className='bg-card border rounded-lg p-6'>
               <div className='flex items-center gap-3 mb-4'>
                 <FileText className='h-6 w-6 text-primary' />
@@ -105,67 +95,116 @@ export default function HerramientasAdminPage() {
                     Herramienta de Justificaciones
                   </h2>
                   <p className='text-muted-foreground'>
-                    Justificar faltas de empleados de manera individual,
-                    departamental o masiva para prevenir generación automática
-                    de faltas
+                    Justificar faltas para prevenir la generación automática de
+                    incidencias.
                   </p>
                 </div>
               </div>
-
-              {/* JustificacionForm Component with Error Boundary */}
-              <Suspense
-                fallback={
-                  <LoadingComponent title='Herramienta de Justificaciones' />
-                }
-              >
+              <Suspense fallback={<LoadingComponent title='Justificaciones' />}>
                 <JustificacionForm />
               </Suspense>
             </div>
           </TabsContent>
 
-          {/* Registro Manual Tab */}
-          <TabsContent value='registro-manual' className='space-y-6'>
-            <div className='bg-card border rounded-lg p-6'>
-              <div className='flex items-center gap-3 mb-4'>
-                <Clock className='h-6 w-6 text-primary' />
-                <div>
-                  <h2 className='text-xl font-semibold'>Registro Manual</h2>
-                  <p className='text-muted-foreground'>
-                    Crear registros de checada retroactivos para corregir
-                    omisiones de empleados
-                  </p>
+          {/* Pestaña 2: Herramientas Agrupadas para Registros y Checadas */}
+          <TabsContent value='registros-checadas'>
+            <div className='grid grid-cols-1 lg:grid-cols-2 gap-6'>
+              {/* Herramienta de Registro Manual */}
+              <div className='bg-card border rounded-lg p-6 flex flex-col'>
+                <div className='flex items-center gap-3 mb-4'>
+                  <Clock className='h-6 w-6 text-primary' />
+                  <div>
+                    <h2 className='text-xl font-semibold'>
+                      Registro Manual de Checadas
+                    </h2>
+                    <p className='text-muted-foreground'>
+                      Crear registros retroactivos para corregir omisiones.
+                    </p>
+                  </div>
+                </div>
+                <div className='flex-grow'>
+                  <Suspense
+                    fallback={<LoadingComponent title='Registro Manual' />}
+                  >
+                    <RegistroManualForm />
+                  </Suspense>
                 </div>
               </div>
 
-              {/* RegistroManualForm Component with Error Boundary */}
-              <Suspense fallback={<LoadingComponent title='Registro Manual' />}>
-                <RegistroManualForm />
-              </Suspense>
+              {/* Herramienta de Corrección de Registros (Detalle) */}
+              <div className='bg-card border rounded-lg p-6 flex flex-col'>
+                <div className='flex items-center gap-3 mb-4'>
+                  <ClipboardList className='h-6 w-6 text-primary' />
+                  <div>
+                    <h2 className='text-xl font-semibold'>
+                      Corrección de Registros
+                    </h2>
+                    <p className='text-muted-foreground'>
+                      Modificar el estatus de checadas individuales.
+                    </p>
+                  </div>
+                </div>
+                <div className='flex-grow'>
+                  <Suspense
+                    fallback={
+                      <LoadingComponent title='Corrección de Registros' />
+                    }
+                  >
+                    <CorreccionRegistrosForm />
+                  </Suspense>
+                </div>
+              </div>
             </div>
           </TabsContent>
 
-          {/* Corrección de Estatus Tab */}
-          <TabsContent value='correccion-estatus' className='space-y-6'>
-            <div className='bg-card border rounded-lg p-6'>
-              <div className='flex items-center gap-3 mb-4'>
-                <Edit3 className='h-6 w-6 text-primary' />
-                <div>
-                  <h2 className='text-xl font-semibold'>
-                    Corrección de Estatus
-                  </h2>
-                  <p className='text-muted-foreground'>
-                    Corregir el estatus de asistencias ya generadas cuando hay
-                    errores o situaciones injustas
-                  </p>
+          {/* Pestaña 3: Herramientas Agrupadas para Asistencias y Procesos */}
+          <TabsContent value='asistencias-procesos'>
+            <div className='grid grid-cols-1 lg:grid-cols-2 gap-6'>
+              {/* Herramienta de Corrección de Asistencia (Consolidado) */}
+              <div className='bg-card border rounded-lg p-6 flex flex-col'>
+                <div className='flex items-center gap-3 mb-4'>
+                  <Edit3 className='h-6 w-6 text-primary' />
+                  <div>
+                    <h2 className='text-xl font-semibold'>
+                      Corrección de Asistencia Diaria
+                    </h2>
+                    <p className='text-muted-foreground'>
+                      Corregir el resultado consolidado de un día.
+                    </p>
+                  </div>
+                </div>
+                <div className='flex-grow'>
+                  <Suspense
+                    fallback={
+                      <LoadingComponent title='Corrección de Asistencia' />
+                    }
+                  >
+                    <CorreccionEstatusForm />
+                  </Suspense>
                 </div>
               </div>
 
-              {/* CorreccionEstatusForm Component with Error Boundary */}
-              <Suspense
-                fallback={<LoadingComponent title='Corrección de Estatus' />}
-              >
-                <CorreccionEstatusForm />
-              </Suspense>
+              {/* Herramienta de Consolidación Manual */}
+              <div className='bg-card border rounded-lg p-6 flex flex-col'>
+                <div className='flex items-center gap-3 mb-4'>
+                  <DatabaseZap className='h-6 w-6 text-primary' />
+                  <div>
+                    <h2 className='text-xl font-semibold'>
+                      Proceso de Consolidación
+                    </h2>
+                    <p className='text-muted-foreground'>
+                      Ejecutar manualmente el cálculo de asistencias diarias.
+                    </p>
+                  </div>
+                </div>
+                <div className='flex-grow'>
+                  <Suspense
+                    fallback={<LoadingComponent title='Consolidación Manual' />}
+                  >
+                    <ConsolidacionManualForm />
+                  </Suspense>
+                </div>
+              </div>
             </div>
           </TabsContent>
         </Tabs>

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -1,12 +1,47 @@
 'use client';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
-import { FileText, Clock, Edit3, Settings } from 'lucide-react';
+import {
+  FileText,
+  Clock,
+  Edit3,
+  Settings,
+  Loader2,
+  AlertCircle,
+} from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { JustificacionForm } from '@/components/admin/JustificacionForm';
 import { RegistroManualForm } from '@/components/admin/RegistroManualForm';
 import { CorreccionEstatusForm } from '@/components/admin/CorreccionEstatusForm';
+
+// Componente de carga para las herramientas
+const LoadingComponent = ({ title }: { title: string }) => (
+  <div className='flex items-center justify-center py-12'>
+    <div className='text-center space-y-4'>
+      <Loader2 className='h-8 w-8 animate-spin mx-auto text-primary' />
+      <div className='text-sm text-muted-foreground'>Cargando {title}...</div>
+    </div>
+  </div>
+);
+
+// Componente de error para las herramientas
+const ErrorComponent = ({ title, error }: { title: string; error: Error }) => (
+  <Alert variant='destructive'>
+    <AlertCircle className='h-4 w-4' />
+    <AlertDescription>
+      <div className='space-y-2'>
+        <div className='font-medium'>Error al cargar {title}</div>
+        <div className='text-sm'>{error.message}</div>
+        <div className='text-xs text-muted-foreground'>
+          Intente recargar la página. Si el problema persiste, contacte al
+          administrador del sistema.
+        </div>
+      </div>
+    </AlertDescription>
+  </Alert>
+);
 
 export default function HerramientasAdminPage() {
   return (
@@ -71,13 +106,20 @@ export default function HerramientasAdminPage() {
                   </h2>
                   <p className='text-muted-foreground'>
                     Justificar faltas de empleados de manera individual,
-                    departamental o masiva
+                    departamental o masiva para prevenir generación automática
+                    de faltas
                   </p>
                 </div>
               </div>
 
-              {/* JustificacionForm Component */}
-              <JustificacionForm />
+              {/* JustificacionForm Component with Error Boundary */}
+              <Suspense
+                fallback={
+                  <LoadingComponent title='Herramienta de Justificaciones' />
+                }
+              >
+                <JustificacionForm />
+              </Suspense>
             </div>
           </TabsContent>
 
@@ -89,13 +131,16 @@ export default function HerramientasAdminPage() {
                 <div>
                   <h2 className='text-xl font-semibold'>Registro Manual</h2>
                   <p className='text-muted-foreground'>
-                    Crear registros de checada retroactivos para empleados
+                    Crear registros de checada retroactivos para corregir
+                    omisiones de empleados
                   </p>
                 </div>
               </div>
 
-              {/* RegistroManualForm Component */}
-              <RegistroManualForm />
+              {/* RegistroManualForm Component with Error Boundary */}
+              <Suspense fallback={<LoadingComponent title='Registro Manual' />}>
+                <RegistroManualForm />
+              </Suspense>
             </div>
           </TabsContent>
 
@@ -109,13 +154,18 @@ export default function HerramientasAdminPage() {
                     Corrección de Estatus
                   </h2>
                   <p className='text-muted-foreground'>
-                    Corregir el estatus de asistencias ya generadas
+                    Corregir el estatus de asistencias ya generadas cuando hay
+                    errores o situaciones injustas
                   </p>
                 </div>
               </div>
 
-              {/* CorreccionEstatusForm Component */}
-              <CorreccionEstatusForm />
+              {/* CorreccionEstatusForm Component with Error Boundary */}
+              <Suspense
+                fallback={<LoadingComponent title='Corrección de Estatus' />}
+              >
+                <CorreccionEstatusForm />
+              </Suspense>
             </div>
           </TabsContent>
         </Tabs>

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import React from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
+import { FileText, Clock, Edit3, Settings } from 'lucide-react';
+
+export default function HerramientasAdminPage() {
+  return (
+    <div className='p-8'>
+      <div className='max-w-7xl mx-auto'>
+        {/* Header with breadcrumbs */}
+        <header className='mb-8'>
+          <BreadcrumbNav
+            items={[
+              { label: 'Admin', href: '/admin' },
+              { label: 'Herramientas' },
+            ]}
+          />
+          <div className='flex items-center gap-3'>
+            <Settings className='h-8 w-8 text-primary' />
+            <div>
+              <h1 className='text-3xl font-bold text-foreground'>
+                Herramientas Administrativas
+              </h1>
+              <p className='text-muted-foreground mt-1'>
+                Gestión de justificaciones, registros manuales y corrección de
+                estatus
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* Tabs Container */}
+        <Tabs defaultValue='justificaciones' className='w-full'>
+          <TabsList className='grid w-full grid-cols-3 mb-8'>
+            <TabsTrigger
+              value='justificaciones'
+              className='flex items-center gap-2'
+            >
+              <FileText className='h-4 w-4' />
+              Justificaciones
+            </TabsTrigger>
+            <TabsTrigger
+              value='registro-manual'
+              className='flex items-center gap-2'
+            >
+              <Clock className='h-4 w-4' />
+              Registro Manual
+            </TabsTrigger>
+            <TabsTrigger
+              value='correccion-estatus'
+              className='flex items-center gap-2'
+            >
+              <Edit3 className='h-4 w-4' />
+              Corrección de Estatus
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Justificaciones Tab */}
+          <TabsContent value='justificaciones' className='space-y-6'>
+            <div className='bg-card border rounded-lg p-6'>
+              <div className='flex items-center gap-3 mb-4'>
+                <FileText className='h-6 w-6 text-primary' />
+                <div>
+                  <h2 className='text-xl font-semibold'>
+                    Herramienta de Justificaciones
+                  </h2>
+                  <p className='text-muted-foreground'>
+                    Justificar faltas de empleados de manera individual,
+                    departamental o masiva
+                  </p>
+                </div>
+              </div>
+
+              {/* Placeholder content - will be replaced with JustificacionForm component */}
+              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
+                <FileText className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
+                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
+                  Formulario de Justificaciones
+                </h3>
+                <p className='text-sm text-muted-foreground'>
+                  El componente JustificacionForm se implementará en la
+                  siguiente tarea
+                </p>
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* Registro Manual Tab */}
+          <TabsContent value='registro-manual' className='space-y-6'>
+            <div className='bg-card border rounded-lg p-6'>
+              <div className='flex items-center gap-3 mb-4'>
+                <Clock className='h-6 w-6 text-primary' />
+                <div>
+                  <h2 className='text-xl font-semibold'>Registro Manual</h2>
+                  <p className='text-muted-foreground'>
+                    Crear registros de checada retroactivos para empleados
+                  </p>
+                </div>
+              </div>
+
+              {/* Placeholder content - will be replaced with RegistroManualForm component */}
+              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
+                <Clock className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
+                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
+                  Formulario de Registro Manual
+                </h3>
+                <p className='text-sm text-muted-foreground'>
+                  El componente RegistroManualForm se implementará en la
+                  siguiente tarea
+                </p>
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* Corrección de Estatus Tab */}
+          <TabsContent value='correccion-estatus' className='space-y-6'>
+            <div className='bg-card border rounded-lg p-6'>
+              <div className='flex items-center gap-3 mb-4'>
+                <Edit3 className='h-6 w-6 text-primary' />
+                <div>
+                  <h2 className='text-xl font-semibold'>
+                    Corrección de Estatus
+                  </h2>
+                  <p className='text-muted-foreground'>
+                    Corregir el estatus de asistencias ya generadas
+                  </p>
+                </div>
+              </div>
+
+              {/* Placeholder content - will be replaced with AsistenciaSearchForm and EstatusCorrecionModal components */}
+              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
+                <Edit3 className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
+                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
+                  Herramienta de Corrección de Estatus
+                </h3>
+                <p className='text-sm text-muted-foreground'>
+                  Los componentes AsistenciaSearchForm y EstatusCorrecionModal
+                  se implementarán en las siguientes tareas
+                </p>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
 import { FileText, Clock, Edit3, Settings } from 'lucide-react';
 import { JustificacionForm } from '@/components/admin/JustificacionForm';
+import { RegistroManualForm } from '@/components/admin/RegistroManualForm';
 
 export default function HerramientasAdminPage() {
   return (
@@ -92,17 +93,8 @@ export default function HerramientasAdminPage() {
                 </div>
               </div>
 
-              {/* Placeholder content - will be replaced with RegistroManualForm component */}
-              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
-                <Clock className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
-                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
-                  Formulario de Registro Manual
-                </h3>
-                <p className='text-sm text-muted-foreground'>
-                  El componente RegistroManualForm se implementará en la
-                  siguiente tarea
-                </p>
-              </div>
+              {/* RegistroManualForm Component */}
+              <RegistroManualForm />
             </div>
           </TabsContent>
 

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
 import { FileText, Clock, Edit3, Settings } from 'lucide-react';
 import { JustificacionForm } from '@/components/admin/JustificacionForm';
 import { RegistroManualForm } from '@/components/admin/RegistroManualForm';
+import { CorreccionEstatusForm } from '@/components/admin/CorreccionEstatusForm';
 
 export default function HerramientasAdminPage() {
   return (
@@ -113,17 +114,8 @@ export default function HerramientasAdminPage() {
                 </div>
               </div>
 
-              {/* Placeholder content - will be replaced with AsistenciaSearchForm and EstatusCorrecionModal components */}
-              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
-                <Edit3 className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
-                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
-                  Herramienta de Corrección de Estatus
-                </h3>
-                <p className='text-sm text-muted-foreground'>
-                  Los componentes AsistenciaSearchForm y EstatusCorrecionModal
-                  se implementarán en las siguientes tareas
-                </p>
-              </div>
+              {/* CorreccionEstatusForm Component */}
+              <CorreccionEstatusForm />
             </div>
           </TabsContent>
         </Tabs>

--- a/app/admin/herramientas/page.tsx
+++ b/app/admin/herramientas/page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BreadcrumbNav } from '@/app/components/shared/breadcrumb-nav';
 import { FileText, Clock, Edit3, Settings } from 'lucide-react';
+import { JustificacionForm } from '@/components/admin/JustificacionForm';
 
 export default function HerramientasAdminPage() {
   return (
@@ -73,17 +74,8 @@ export default function HerramientasAdminPage() {
                 </div>
               </div>
 
-              {/* Placeholder content - will be replaced with JustificacionForm component */}
-              <div className='bg-muted/50 border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center'>
-                <FileText className='h-12 w-12 text-muted-foreground mx-auto mb-4' />
-                <h3 className='text-lg font-medium text-muted-foreground mb-2'>
-                  Formulario de Justificaciones
-                </h3>
-                <p className='text-sm text-muted-foreground'>
-                  El componente JustificacionForm se implementará en la
-                  siguiente tarea
-                </p>
-              </div>
+              {/* JustificacionForm Component */}
+              <JustificacionForm />
             </div>
           </TabsContent>
 

--- a/app/components/shared/SchedulePreviewModal.tsx
+++ b/app/components/shared/SchedulePreviewModal.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { LoadingState } from '@/app/components/shared/loading-state';
+import { ErrorState } from '@/app/components/shared/error-state';
+import SchedulePreview from '@/app/components/shared/SchedulePreview';
+import { HorarioTemplateDTO } from '@/app/horarios/asignados/registrar/types';
+import { Calendar } from 'lucide-react';
+
+interface SchedulePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  template: HorarioTemplateDTO | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function SchedulePreviewModal({
+  isOpen,
+  onClose,
+  template,
+  isLoading,
+  error,
+}: SchedulePreviewModalProps) {
+  const renderContent = () => {
+    if (isLoading) {
+      return <LoadingState message='Cargando horario...' />;
+    }
+    if (error) {
+      return <ErrorState message={error} />;
+    }
+    if (template) {
+      return <SchedulePreview template={template} />;
+    }
+    return (
+      <div className='text-center p-8 text-muted-foreground'>
+        No hay datos de horario para mostrar. Seleccione un empleado y una fecha
+        válida.
+      </div>
+    );
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className='max-w-4xl max-h-[90vh] overflow-y-auto bg-zinc-900 border-zinc-800 text-white'>
+        <DialogHeader>
+          <DialogTitle className='text-2xl font-bold flex items-center gap-2'>
+            <Calendar className='h-6 w-6' />
+            Vista Previa del Horario Asignado
+          </DialogTitle>
+          <DialogDescription>
+            {template
+              ? `Mostrando el horario "${template.nombre}"`
+              : 'Detalles del horario del empleado en la fecha seleccionada.'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className='py-4'>{renderContent()}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/shared/data-table-with-selection.tsx
+++ b/app/components/shared/data-table-with-selection.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Check, Minus } from 'lucide-react';
+import { SortableHeader } from './sortable-header';
+import { PaginationWrapper } from './pagination-wrapper';
+
+interface Column<T> {
+  key: string;
+  label: string;
+  sortable?: boolean;
+  render?: (item: T) => React.ReactNode;
+  className?: string;
+}
+
+interface DataTableWithSelectionProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  currentPage: number;
+  totalPages: number;
+  sortField: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSort: (field: string) => void;
+  onPageChange: (page: number) => void;
+  // Nuevas props para selección múltiple
+  enableSelection?: boolean;
+  selectedIds: number[];
+  onSelectionChange: (selectedIds: number[]) => void;
+  getItemId: (item: T) => number;
+  // Props existentes
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function DataTableWithSelection<T extends Record<string, any>>({
+  data,
+  columns,
+  currentPage,
+  totalPages,
+  sortField,
+  sortDirection,
+  onSort,
+  onPageChange,
+  enableSelection = false,
+  selectedIds,
+  onSelectionChange,
+  getItemId,
+  emptyMessage = 'No se encontraron datos.',
+  className = '',
+}: DataTableWithSelectionProps<T>) {
+  // ============================================================================
+  // HANDLERS DE SELECCIÓN
+  // ============================================================================
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      const allIds = data.map((item) => getItemId(item));
+      onSelectionChange(allIds);
+    } else {
+      onSelectionChange([]);
+    }
+  };
+
+  const handleSelectItem = (itemId: number, checked: boolean) => {
+    if (checked) {
+      onSelectionChange([...selectedIds, itemId]);
+    } else {
+      onSelectionChange(selectedIds.filter((id) => id !== itemId));
+    }
+  };
+
+  // ============================================================================
+  // ESTADO DE SELECCIÓN
+  // ============================================================================
+
+  const isAllSelected = data.length > 0 && selectedIds.length === data.length;
+  const isIndeterminate =
+    selectedIds.length > 0 && selectedIds.length < data.length;
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <>
+      <div className={`overflow-x-auto rounded-lg border ${className}`}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {/* Columna de checkbox para selección múltiple */}
+              {enableSelection && (
+                <TableHead className='w-12'>
+                  {isIndeterminate ? (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-4 w-4 p-0 border border-primary'
+                      onClick={() => handleSelectAll(false)}
+                      aria-label='Deseleccionar todos'
+                    >
+                      <Minus className='h-3 w-3' />
+                    </Button>
+                  ) : (
+                    <Checkbox
+                      checked={isAllSelected}
+                      onCheckedChange={handleSelectAll}
+                      aria-label='Seleccionar todos'
+                    />
+                  )}
+                </TableHead>
+              )}
+
+              {/* Columnas de datos */}
+              {columns.map((column) =>
+                column.sortable ? (
+                  <SortableHeader
+                    key={column.key}
+                    field={column.key}
+                    sortField={sortField}
+                    sortDirection={sortDirection}
+                    onSort={onSort}
+                  >
+                    {column.label}
+                  </SortableHeader>
+                ) : (
+                  <TableHead key={column.key} className={column.className}>
+                    {column.label}
+                  </TableHead>
+                )
+              )}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.length > 0 ? (
+              data.map((item, index) => {
+                const itemId = getItemId(item);
+                const isSelected = selectedIds.includes(itemId);
+
+                return (
+                  <TableRow
+                    key={itemId || index}
+                    className={isSelected ? 'bg-muted/50' : ''}
+                  >
+                    {/* Celda de checkbox */}
+                    {enableSelection && (
+                      <TableCell>
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={(checked) =>
+                            handleSelectItem(itemId, checked as boolean)
+                          }
+                          aria-label={`Seleccionar fila ${index + 1}`}
+                        />
+                      </TableCell>
+                    )}
+
+                    {/* Celdas de datos */}
+                    {columns.map((column) => (
+                      <TableCell key={column.key} className={column.className}>
+                        {column.render ? column.render(item) : item[column.key]}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                );
+              })
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length + (enableSelection ? 1 : 0)}
+                  className='text-center h-24'
+                >
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <PaginationWrapper
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+      />
+    </>
+  );
+}

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Monitor,
   BarChart2,
   LogOut,
+  Settings,
 } from 'lucide-react';
 import { useSidebar } from '../../hooks/use-sidebar';
 import { useAuth } from '../context/AuthContext';
@@ -129,7 +130,24 @@ const navItems: NavItemData[] = [
     ],
   },
 
-  // 5. Reportes (A futuro)
+  // 5. Herramientas Administrativas
+  {
+    id: 'herramientas',
+    href: '/admin/herramientas',
+    icon: <Settings size={20} />,
+    text: 'Herramientas',
+    keywords: [
+      'herramientas',
+      'justificaciones',
+      'registro',
+      'manual',
+      'correccion',
+      'estatus',
+      'admin',
+    ],
+  },
+
+  // 6. Reportes (A futuro)
   {
     id: 'reportes',
     href: '/reportes',

--- a/components/admin/AsistenciaSearchForm.tsx
+++ b/components/admin/AsistenciaSearchForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Search, Calendar as CalendarIcon, Filter, X } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -29,153 +29,80 @@ import { EmpleadoSimpleDTO } from '@/app/horarios/asignados/registrar/types';
 import { DepartamentoDto } from '@/lib/api/schedule-api';
 import { AsistenciaFilters, EstatusDisponible } from '@/lib/api/asistencia.api';
 
-// ============================================================================
-// INTERFACES
-// ============================================================================
-
 interface AsistenciaSearchFormProps {
-  filters: AsistenciaFilters;
+  initialFilters?: AsistenciaFilters;
   estatusDisponibles: EstatusDisponible[];
   loading: boolean;
   onSearch: (filters: AsistenciaFilters) => void;
   onClearFilters: () => void;
-  // Si es true, se oculta el rango y se exige una fecha única (modo corrección)
-  singleDate?: boolean;
+  showDateRange?: boolean;
+  requireDate?: boolean;
+  requireStatus?: boolean;
 }
-
-interface FormData {
-  empleado: EmpleadoSimpleDTO | null;
-  departamento: DepartamentoDto | null;
-  fechaInicio: Date | undefined;
-  fechaFin: Date | undefined;
-  estatus: EstatusDisponible | null;
-}
-
-// ============================================================================
-// COMPONENTE PRINCIPAL
-// ============================================================================
 
 export function AsistenciaSearchForm({
-  filters,
+  initialFilters = {},
   estatusDisponibles,
   loading,
   onSearch,
   onClearFilters,
-  singleDate = false,
+  showDateRange = false,
+  requireDate = false,
+  requireStatus = false,
 }: AsistenciaSearchFormProps) {
-  const [formData, setFormData] = useState<FormData>({
-    empleado: null,
-    departamento: null,
-    fechaInicio: undefined,
-    fechaFin: undefined,
-    estatus: null,
-  });
-
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  // Memoizar handlers para evitar re-renders innecesarios
-  const handleEstatusChange = React.useCallback(
-    (value: string) => {
-      const selectedEstatus = estatusDisponibles.find(
-        (e) => e.id.toString() === value
-      );
-      setFormData((prev) => ({ ...prev, estatus: selectedEstatus || null }));
-    },
-    [estatusDisponibles]
+  const [empleado, setEmpleado] = useState<EmpleadoSimpleDTO | null>(null);
+  const [departamento, setDepartamento] = useState<DepartamentoDto | null>(
+    null
   );
-
-  const handleEmpleadoChange = React.useCallback(
-    (empleado: EmpleadoSimpleDTO | null) => {
-      setFormData((prev) => ({ ...prev, empleado }));
-    },
-    []
-  );
-
-  const handleDepartamentoChange = React.useCallback(
-    (departamento: DepartamentoDto | null) => {
-      setFormData((prev) => ({ ...prev, departamento }));
-    },
-    []
-  );
-
-  const handleFechaInicioChange = React.useCallback(
-    (date: Date | undefined) => {
-      setFormData((prev) => ({ ...prev, fechaInicio: date }));
-    },
-    []
-  );
-
-  const handleFechaFinChange = React.useCallback((date: Date | undefined) => {
-    setFormData((prev) => ({ ...prev, fechaFin: date }));
-  }, []);
-
-  // ============================================================================
-  // VALIDACIÓN
-  // ============================================================================
-
-  const validateForm = (): boolean => {
-    const newErrors: Record<string, string> = {};
-
-    // Según la guía técnica, AMBOS parámetros son requeridos para el endpoint de búsqueda
-    const hasDate = Boolean(formData.fechaInicio);
-    const hasStatus = Boolean(formData.estatus);
-
-    if (!hasDate) {
-      newErrors.fecha = 'Debe seleccionar una fecha para realizar la búsqueda.';
-    }
-
-    if (!hasStatus) {
-      newErrors.estatus =
-        'Debe seleccionar un estatus para realizar la búsqueda.';
-    }
-
-    if (!hasDate || !hasStatus) {
-      newErrors.general =
-        'Debe seleccionar tanto una fecha como un estatus para realizar la búsqueda.';
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  // ============================================================================
-  // HANDLERS
-  // ============================================================================
+  const [fechaInicio, setFechaInicio] = useState<Date | undefined>(undefined);
+  const [fechaFin, setFechaFin] = useState<Date | undefined>(undefined);
+  const [estatus, setEstatus] = useState<EstatusDisponible | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSearch = () => {
-    if (!validateForm()) return;
-
-    // Según la guía técnica, solo necesitamos estatusId y fecha
-    const searchFilters: AsistenciaFilters = {
-      estatusId: formData.estatus!.id,
-      fecha: format(formData.fechaInicio!, 'yyyy-MM-dd'),
-    };
-
-    onSearch(searchFilters);
+    setError(null);
+    if (requireDate) {
+      if (!fechaInicio) {
+        setError(
+          showDateRange
+            ? 'La fecha de inicio es obligatoria.'
+            : 'La fecha es obligatoria.'
+        );
+        return;
+      }
+      if (showDateRange && !fechaFin) {
+        setFechaFin(fechaInicio);
+      }
+    }
+    if (requireStatus && !estatus) {
+      setError('Debe seleccionar un estatus.');
+      return;
+    }
+    onSearch({
+      empleadoId: empleado?.id,
+      departamentoClave: departamento?.clave,
+      fechaInicio: fechaInicio ? format(fechaInicio, 'yyyy-MM-dd') : undefined,
+      fechaFin: fechaFin
+        ? format(fechaFin, 'yyyy-MM-dd')
+        : showDateRange && fechaInicio
+          ? format(fechaInicio, 'yyyy-MM-dd')
+          : undefined,
+      estatusClave: estatus?.clave,
+    });
   };
 
-  const handleClearFilters = () => {
-    setFormData({
-      empleado: null,
-      departamento: null,
-      fechaInicio: undefined,
-      fechaFin: undefined,
-      estatus: null,
-    });
-    setErrors({});
+  const handleClear = () => {
+    setEmpleado(null);
+    setDepartamento(null);
+    setFechaInicio(undefined);
+    setFechaFin(undefined);
+    setEstatus(null);
+    setError(null);
     onClearFilters();
   };
 
   const hasActiveFilters =
-    formData.empleado ||
-    formData.departamento ||
-    formData.fechaInicio ||
-    formData.fechaFin ||
-    formData.estatus;
-
-  // ============================================================================
-  // RENDER
-  // ============================================================================
+    empleado || departamento || fechaInicio || fechaFin || estatus;
 
   return (
     <Card>
@@ -186,155 +113,142 @@ export function AsistenciaSearchForm({
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-6'>
-        {/* Error general */}
-        {errors.general && (
-          <div className='p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md'>
-            {errors.general}
+        {error && (
+          <div className='p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md'>
+            {error}
           </div>
         )}
 
-        {/* Fila 1: Empleado y Departamento */}
         <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
           <div className='space-y-2'>
-            <Label htmlFor='empleado'>Empleado</Label>
+            <Label>Empleado (Opcional)</Label>
             <EmployeeSearch
-              value={formData.empleado}
-              onChange={handleEmpleadoChange}
-              placeholder='Buscar empleado...'
+              value={empleado}
+              onChange={setEmpleado}
               disabled={loading}
             />
           </div>
-
           <div className='space-y-2'>
-            <Label htmlFor='departamento'>Departamento</Label>
+            <Label>Departamento (Opcional)</Label>
             <DepartmentSearch
-              value={formData.departamento}
-              onChange={handleDepartamentoChange}
-              placeholder='Buscar departamento...'
+              value={departamento}
+              onChange={setDepartamento}
               disabled={loading}
             />
           </div>
         </div>
 
-        {/* Fechas */}
         <div
-          className={`grid grid-cols-1 ${singleDate ? '' : 'md:grid-cols-2'} gap-4`}
+          className={`grid grid-cols-1 ${showDateRange ? 'md:grid-cols-2' : ''} gap-4`}
         >
           <div className='space-y-2'>
-            <Label>{singleDate ? 'Fecha' : 'Fecha Inicio'}</Label>
+            <Label>
+              {showDateRange ? 'Fecha Inicio' : 'Fecha'}{' '}
+              {requireDate && <span className='text-destructive'>*</span>}
+            </Label>
             <Popover>
               <PopoverTrigger asChild>
                 <Button
                   variant='outline'
                   className={cn(
                     'w-full justify-start text-left font-normal',
-                    !formData.fechaInicio && 'text-muted-foreground'
+                    !fechaInicio && 'text-muted-foreground'
                   )}
                   disabled={loading}
                 >
                   <CalendarIcon className='mr-2 h-4 w-4' />
-                  {formData.fechaInicio
-                    ? format(formData.fechaInicio, 'PPP', { locale: es })
-                    : singleDate
-                      ? 'Seleccionar fecha'
-                      : 'Seleccionar fecha inicio'}
+                  {fechaInicio
+                    ? format(fechaInicio, 'PPP', { locale: es })
+                    : 'Seleccionar fecha'}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className='w-auto p-0' align='start'>
+              <PopoverContent className='w-auto p-0'>
                 <Calendar
                   mode='single'
-                  selected={formData.fechaInicio}
-                  onSelect={handleFechaInicioChange}
-                  disabled={{ after: new Date() }}
-                  initialFocus
+                  selected={fechaInicio}
+                  onSelect={(d) => setFechaInicio(d || undefined)}
                 />
               </PopoverContent>
             </Popover>
           </div>
-          {!singleDate && (
+          {showDateRange && (
             <div className='space-y-2'>
-              <Label>Fecha Fin</Label>
+              <Label>
+                Fecha Fin{' '}
+                {requireDate && <span className='text-destructive'>*</span>}
+              </Label>
               <Popover>
                 <PopoverTrigger asChild>
                   <Button
                     variant='outline'
                     className={cn(
                       'w-full justify-start text-left font-normal',
-                      !formData.fechaFin && 'text-muted-foreground'
+                      !fechaFin && 'text-muted-foreground'
                     )}
                     disabled={loading}
                   >
                     <CalendarIcon className='mr-2 h-4 w-4' />
-                    {formData.fechaFin
-                      ? format(formData.fechaFin, 'PPP', { locale: es })
-                      : 'Seleccionar fecha fin'}
+                    {fechaFin
+                      ? format(fechaFin, 'PPP', { locale: es })
+                      : 'Seleccionar fecha'}
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className='w-auto p-0' align='start'>
+                <PopoverContent className='w-auto p-0'>
                   <Calendar
                     mode='single'
-                    selected={formData.fechaFin}
-                    onSelect={handleFechaFinChange}
-                    disabled={{
-                      after: new Date(),
-                      before: formData.fechaInicio,
-                    }}
-                    initialFocus
+                    selected={fechaFin}
+                    onSelect={(d) => setFechaFin(d || undefined)}
+                    disabled={fechaInicio ? { before: fechaInicio } : undefined}
                   />
                 </PopoverContent>
               </Popover>
-              {errors.fechaFin && (
-                <p className='text-sm text-red-600'>{errors.fechaFin}</p>
-              )}
             </div>
           )}
         </div>
 
-        {/* Fila 3: Estatus */}
         <div className='space-y-2'>
-          <Label htmlFor='estatus'>Estatus Actual</Label>
+          <Label>Estatus (Opcional)</Label>
           <Select
-            value={formData.estatus?.id.toString() || ''}
-            onValueChange={handleEstatusChange}
+            value={estatus?.id.toString() || 'ALL'}
+            onValueChange={(value) => {
+              if (value === 'ALL') {
+                setEstatus(null);
+              } else {
+                setEstatus(
+                  estatusDisponibles.find((e) => e.id.toString() === value) ||
+                    null
+                );
+              }
+            }}
             disabled={loading}
           >
             <SelectTrigger>
-              <SelectValue placeholder='Seleccionar estatus...' />
+              <SelectValue placeholder='Todos los estatus...' />
             </SelectTrigger>
             <SelectContent>
-              {estatusDisponibles.map((estatus) => (
-                <SelectItem key={estatus.id} value={estatus.id.toString()}>
-                  <div className='flex items-center gap-2'>
-                    {estatus.color && (
-                      <div
-                        className='w-3 h-3 rounded-full'
-                        style={{ backgroundColor: estatus.color }}
-                      />
-                    )}
-                    <span>{estatus.nombre}</span>
-                  </div>
+              <SelectItem value='ALL'>Todos</SelectItem>
+              {estatusDisponibles.map((e) => (
+                <SelectItem key={e.id} value={e.id.toString()}>
+                  {e.nombre}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
 
-        {/* Botones de acción */}
         <div className='flex flex-col sm:flex-row gap-3 pt-4'>
           <Button onClick={handleSearch} disabled={loading} className='flex-1'>
             <Search className='mr-2 h-4 w-4' />
             {loading ? 'Buscando...' : 'Buscar Asistencias'}
           </Button>
-
           {hasActiveFilters && (
             <Button
               variant='outline'
-              onClick={handleClearFilters}
+              onClick={handleClear}
               disabled={loading}
               className='flex-1 sm:flex-none'
             >
-              <X className='mr-2 h-4 w-4' />
-              Limpiar Filtros
+              <X className='mr-2 h-4 w-4' /> Limpiar Filtros
             </Button>
           )}
         </div>

--- a/components/admin/AsistenciaSearchForm.tsx
+++ b/components/admin/AsistenciaSearchForm.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Search, Calendar as CalendarIcon, Filter, X } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { cn } from '@/lib/utils';
+
+import { EmployeeSearch } from '@/app/components/shared/employee-search';
+import { DepartmentSearch } from './DepartmentSearch';
+import { EmpleadoSimpleDTO } from '@/app/horarios/asignados/registrar/types';
+import { DepartamentoDto } from '@/lib/api/schedule-api';
+import { AsistenciaFilters, EstatusDisponible } from '@/lib/api/asistencia.api';
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+interface AsistenciaSearchFormProps {
+  filters: AsistenciaFilters;
+  estatusDisponibles: EstatusDisponible[];
+  loading: boolean;
+  onSearch: (filters: AsistenciaFilters) => void;
+  onClearFilters: () => void;
+  // Si es true, se oculta el rango y se exige una fecha única (modo corrección)
+  singleDate?: boolean;
+}
+
+interface FormData {
+  empleado: EmpleadoSimpleDTO | null;
+  departamento: DepartamentoDto | null;
+  fechaInicio: Date | undefined;
+  fechaFin: Date | undefined;
+  estatus: EstatusDisponible | null;
+}
+
+// ============================================================================
+// COMPONENTE PRINCIPAL
+// ============================================================================
+
+export function AsistenciaSearchForm({
+  filters,
+  estatusDisponibles,
+  loading,
+  onSearch,
+  onClearFilters,
+  singleDate = false,
+}: AsistenciaSearchFormProps) {
+  const [formData, setFormData] = useState<FormData>({
+    empleado: null,
+    departamento: null,
+    fechaInicio: undefined,
+    fechaFin: undefined,
+    estatus: null,
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Memoizar handlers para evitar re-renders innecesarios
+  const handleEstatusChange = React.useCallback(
+    (value: string) => {
+      const selectedEstatus = estatusDisponibles.find(
+        (e) => e.id.toString() === value
+      );
+      setFormData((prev) => ({ ...prev, estatus: selectedEstatus || null }));
+    },
+    [estatusDisponibles]
+  );
+
+  const handleEmpleadoChange = React.useCallback(
+    (empleado: EmpleadoSimpleDTO | null) => {
+      setFormData((prev) => ({ ...prev, empleado }));
+    },
+    []
+  );
+
+  const handleDepartamentoChange = React.useCallback(
+    (departamento: DepartamentoDto | null) => {
+      setFormData((prev) => ({ ...prev, departamento }));
+    },
+    []
+  );
+
+  const handleFechaInicioChange = React.useCallback(
+    (date: Date | undefined) => {
+      setFormData((prev) => ({ ...prev, fechaInicio: date }));
+    },
+    []
+  );
+
+  const handleFechaFinChange = React.useCallback((date: Date | undefined) => {
+    setFormData((prev) => ({ ...prev, fechaFin: date }));
+  }, []);
+
+  // ============================================================================
+  // VALIDACIÓN
+  // ============================================================================
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // Según la guía técnica, AMBOS parámetros son requeridos para el endpoint de búsqueda
+    const hasDate = Boolean(formData.fechaInicio);
+    const hasStatus = Boolean(formData.estatus);
+
+    if (!hasDate) {
+      newErrors.fecha = 'Debe seleccionar una fecha para realizar la búsqueda.';
+    }
+
+    if (!hasStatus) {
+      newErrors.estatus =
+        'Debe seleccionar un estatus para realizar la búsqueda.';
+    }
+
+    if (!hasDate || !hasStatus) {
+      newErrors.general =
+        'Debe seleccionar tanto una fecha como un estatus para realizar la búsqueda.';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // ============================================================================
+  // HANDLERS
+  // ============================================================================
+
+  const handleSearch = () => {
+    if (!validateForm()) return;
+
+    // Según la guía técnica, solo necesitamos estatusId y fecha
+    const searchFilters: AsistenciaFilters = {
+      estatusId: formData.estatus!.id,
+      fecha: format(formData.fechaInicio!, 'yyyy-MM-dd'),
+    };
+
+    onSearch(searchFilters);
+  };
+
+  const handleClearFilters = () => {
+    setFormData({
+      empleado: null,
+      departamento: null,
+      fechaInicio: undefined,
+      fechaFin: undefined,
+      estatus: null,
+    });
+    setErrors({});
+    onClearFilters();
+  };
+
+  const hasActiveFilters =
+    formData.empleado ||
+    formData.departamento ||
+    formData.fechaInicio ||
+    formData.fechaFin ||
+    formData.estatus;
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <Filter className='h-5 w-5' />
+          Filtros de Búsqueda
+        </CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-6'>
+        {/* Error general */}
+        {errors.general && (
+          <div className='p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md'>
+            {errors.general}
+          </div>
+        )}
+
+        {/* Fila 1: Empleado y Departamento */}
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+          <div className='space-y-2'>
+            <Label htmlFor='empleado'>Empleado</Label>
+            <EmployeeSearch
+              value={formData.empleado}
+              onChange={handleEmpleadoChange}
+              placeholder='Buscar empleado...'
+              disabled={loading}
+            />
+          </div>
+
+          <div className='space-y-2'>
+            <Label htmlFor='departamento'>Departamento</Label>
+            <DepartmentSearch
+              value={formData.departamento}
+              onChange={handleDepartamentoChange}
+              placeholder='Buscar departamento...'
+              disabled={loading}
+            />
+          </div>
+        </div>
+
+        {/* Fechas */}
+        <div
+          className={`grid grid-cols-1 ${singleDate ? '' : 'md:grid-cols-2'} gap-4`}
+        >
+          <div className='space-y-2'>
+            <Label>{singleDate ? 'Fecha' : 'Fecha Inicio'}</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant='outline'
+                  className={cn(
+                    'w-full justify-start text-left font-normal',
+                    !formData.fechaInicio && 'text-muted-foreground'
+                  )}
+                  disabled={loading}
+                >
+                  <CalendarIcon className='mr-2 h-4 w-4' />
+                  {formData.fechaInicio
+                    ? format(formData.fechaInicio, 'PPP', { locale: es })
+                    : singleDate
+                      ? 'Seleccionar fecha'
+                      : 'Seleccionar fecha inicio'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className='w-auto p-0' align='start'>
+                <Calendar
+                  mode='single'
+                  selected={formData.fechaInicio}
+                  onSelect={handleFechaInicioChange}
+                  disabled={{ after: new Date() }}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+          {!singleDate && (
+            <div className='space-y-2'>
+              <Label>Fecha Fin</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant='outline'
+                    className={cn(
+                      'w-full justify-start text-left font-normal',
+                      !formData.fechaFin && 'text-muted-foreground'
+                    )}
+                    disabled={loading}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {formData.fechaFin
+                      ? format(formData.fechaFin, 'PPP', { locale: es })
+                      : 'Seleccionar fecha fin'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0' align='start'>
+                  <Calendar
+                    mode='single'
+                    selected={formData.fechaFin}
+                    onSelect={handleFechaFinChange}
+                    disabled={{
+                      after: new Date(),
+                      before: formData.fechaInicio,
+                    }}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+              {errors.fechaFin && (
+                <p className='text-sm text-red-600'>{errors.fechaFin}</p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Fila 3: Estatus */}
+        <div className='space-y-2'>
+          <Label htmlFor='estatus'>Estatus Actual</Label>
+          <Select
+            value={formData.estatus?.id.toString() || ''}
+            onValueChange={handleEstatusChange}
+            disabled={loading}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder='Seleccionar estatus...' />
+            </SelectTrigger>
+            <SelectContent>
+              {estatusDisponibles.map((estatus) => (
+                <SelectItem key={estatus.id} value={estatus.id.toString()}>
+                  <div className='flex items-center gap-2'>
+                    {estatus.color && (
+                      <div
+                        className='w-3 h-3 rounded-full'
+                        style={{ backgroundColor: estatus.color }}
+                      />
+                    )}
+                    <span>{estatus.nombre}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Botones de acción */}
+        <div className='flex flex-col sm:flex-row gap-3 pt-4'>
+          <Button onClick={handleSearch} disabled={loading} className='flex-1'>
+            <Search className='mr-2 h-4 w-4' />
+            {loading ? 'Buscando...' : 'Buscar Asistencias'}
+          </Button>
+
+          {hasActiveFilters && (
+            <Button
+              variant='outline'
+              onClick={handleClearFilters}
+              disabled={loading}
+              className='flex-1 sm:flex-none'
+            >
+              <X className='mr-2 h-4 w-4' />
+              Limpiar Filtros
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/ConsolidacionManualForm.tsx
+++ b/components/admin/ConsolidacionManualForm.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Calendar as CalendarIcon,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  DatabaseZap,
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/components/ui/use-toast';
+
+import { getApiErrorMessage } from '@/lib/api/api-helpers';
+import {
+  consolidarAsistenciaManual,
+  ConsolidacionResponse,
+} from '@/lib/api/asistencia.api';
+
+export function ConsolidacionManualForm() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successInfo, setSuccessInfo] = useState<ConsolidacionResponse | null>(
+    null
+  );
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [isConfirmOpen, setConfirmOpen] = useState(false);
+
+  const validateForm = (): boolean => {
+    if (!selectedDate) {
+      setError('Debe seleccionar una fecha para consolidar.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessInfo(null);
+    if (validateForm()) {
+      setConfirmOpen(true);
+    }
+  };
+
+  const handleConfirmSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    setConfirmOpen(false);
+
+    try {
+      const fechaFormateada = format(selectedDate!, 'yyyy-MM-dd');
+      const response = await consolidarAsistenciaManual(fechaFormateada);
+
+      setSuccessInfo(response);
+      toast({
+        title: 'Consolidación Exitosa',
+        description:
+          response.mensaje ||
+          `Se procesaron ${response.registrosConsolidados} registros.`,
+      });
+      setSelectedDate(null); // Reset date after success
+    } catch (err) {
+      const errorMessage = getApiErrorMessage(err);
+      setError(errorMessage);
+      toast({
+        title: 'Error en la Consolidación',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Consolidar Asistencias por Fecha</CardTitle>
+          <CardDescription>
+            Seleccione una fecha para ejecutar manualmente el proceso de
+            consolidación diaria.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant='destructive' className='mb-4'>
+              <AlertCircle className='h-4 w-4' />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {successInfo && (
+            <Alert className='mb-4 border-green-500/50 text-green-700 dark:text-green-400 [&>svg]:text-green-700 dark:[&>svg]:text-green-400'>
+              <CheckCircle2 className='h-4 w-4' />
+              <AlertTitle>¡Proceso Completado!</AlertTitle>
+              <AlertDescription>
+                <strong>{successInfo.registrosConsolidados}</strong> registros
+                fueron procesados para la fecha seleccionada.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <form onSubmit={handleSubmit} className='space-y-6'>
+            <div className='space-y-2'>
+              <Label>Fecha a Consolidar</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant='outline'
+                    className='w-full justify-start text-left font-normal'
+                    disabled={loading}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {selectedDate ? (
+                      format(selectedDate, 'PPP', { locale: es })
+                    ) : (
+                      <span>Seleccione una fecha</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0'>
+                  <Calendar
+                    mode='single'
+                    selected={selectedDate ?? undefined}
+                    onSelect={(d) => {
+                      setSelectedDate(d || null);
+                      setError(null);
+                    }}
+                    disabled={(date) => date > new Date()}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <Button
+              type='submit'
+              disabled={loading || !selectedDate}
+              className='w-full'
+            >
+              {loading ? (
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              ) : (
+                <DatabaseZap className='mr-2 h-4 w-4' />
+              )}
+              {loading ? 'Procesando...' : 'Consolidar Asistencias'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={isConfirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Confirmar Consolidación?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción ejecutará el proceso de consolidación para la fecha{' '}
+              <strong>
+                {selectedDate
+                  ? format(selectedDate, 'PPP', { locale: es })
+                  : ''}
+              </strong>
+              . Esto puede sobrescribir datos de asistencia existentes para esa
+              fecha si se han realizado cambios manuales. ¿Desea continuar?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={loading}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmSubmit} disabled={loading}>
+              {loading ? (
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              ) : (
+                'Confirmar'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/components/admin/CorreccionEstatusForm.tsx
+++ b/components/admin/CorreccionEstatusForm.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { Edit3, Users, AlertCircle, CheckCircle2 } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+
+import { AsistenciaSearchForm } from './AsistenciaSearchForm';
+import { EstatusCorrecionModal } from './EstatusCorrecionModal';
+import { DataTableWithSelection } from '@/app/components/shared/data-table-with-selection';
+import { useCorreccionEstatusReducer } from '@/lib/hooks/useCorreccionEstatusReducer';
+import {
+  buscarAsistencias,
+  getEstatusDisponibles,
+  AsistenciaRecord,
+  AsistenciaFilters,
+} from '@/lib/api/asistencia.api';
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+interface Column {
+  key: string;
+  label: string;
+  sortable?: boolean;
+  render?: (item: AsistenciaRecord) => React.ReactNode;
+  className?: string;
+}
+
+// ============================================================================
+// COMPONENTE PRINCIPAL
+// ============================================================================
+
+export function CorreccionEstatusForm() {
+  const { state, actions } = useCorreccionEstatusReducer();
+  const { toast } = useToast();
+
+  // ============================================================================
+  // EFECTOS
+  // ============================================================================
+
+  // Cargar estatus disponibles al montar el componente
+  useEffect(() => {
+    const loadEstatusDisponibles = async () => {
+      actions.setLoading('loadingEstatus', true);
+      actions.setError('estatus', undefined);
+
+      try {
+        const estatus = await getEstatusDisponibles();
+        actions.setEstatusDisponibles(estatus);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Error al cargar estatus disponibles';
+        actions.setError('estatus', errorMessage);
+        toast({
+          title: 'Error',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+      } finally {
+        actions.setLoading('loadingEstatus', false);
+      }
+    };
+
+    // Solo cargar si no hay estatus disponibles y no está cargando
+    if (
+      (!state.estatusDisponibles || state.estatusDisponibles.length === 0) &&
+      !state.loading.loadingEstatus
+    ) {
+      loadEstatusDisponibles();
+    }
+  }, [
+    actions,
+    toast,
+    state.estatusDisponibles?.length,
+    state.loading.loadingEstatus,
+  ]);
+
+  // ============================================================================
+  // HANDLERS MEMOIZADOS
+  // ============================================================================
+
+  const handleSearch = React.useCallback(
+    async (filters: AsistenciaFilters) => {
+      actions.setLoading('searching', true);
+      actions.setError('search', undefined);
+      actions.clearSelection();
+
+      try {
+        const results = await buscarAsistencias(filters, 1, 50);
+        actions.setSearchResults(results);
+        actions.setFilters(filters);
+
+        toast({
+          title: 'Búsqueda completada',
+          description: `Se encontraron ${results.total} registros.`,
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Error al buscar asistencias';
+        actions.setError('search', errorMessage);
+        toast({
+          title: 'Error en la búsqueda',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+      } finally {
+        actions.setLoading('searching', false);
+      }
+    },
+    [actions, toast]
+  );
+
+  const handleClearFilters = React.useCallback(() => {
+    actions.setFilters({});
+    actions.setSearchResults({
+      asistencias: [],
+      total: 0,
+      pagina: 1,
+      totalPaginas: 0,
+    });
+    actions.clearSelection();
+    actions.clearErrors();
+  }, [actions]);
+
+  const handlePageChange = React.useCallback(
+    async (page: number) => {
+      if (Object.keys(state.filters).length === 0) return;
+
+      actions.setLoading('searching', true);
+
+      try {
+        const results = await buscarAsistencias(
+          state.filters as AsistenciaFilters,
+          page,
+          50
+        );
+        actions.setSearchResults(results);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Error al cambiar página';
+        toast({
+          title: 'Error',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+      } finally {
+        actions.setLoading('searching', false);
+      }
+    },
+    [actions, state.filters, toast]
+  );
+
+  const handleSort = React.useCallback((field: string) => {
+    // TODO: Implementar ordenamiento si el backend lo soporta
+    console.log('Sort by:', field);
+  }, []);
+
+  const handleModalSuccess = React.useCallback(async () => {
+    // Refrescar los resultados de búsqueda después de una corrección exitosa
+    if (Object.keys(state.filters).length > 0) {
+      actions.setLoading('searching', true);
+
+      try {
+        const results = await buscarAsistencias(
+          state.filters as AsistenciaFilters,
+          state.pagination?.currentPage || 1,
+          50
+        );
+        actions.setSearchResults(results);
+        actions.clearSelection(); // Limpiar selección después de la corrección
+
+        toast({
+          title: 'Datos actualizados',
+          description: 'La tabla se ha actualizado con los cambios realizados.',
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Error al actualizar los datos';
+        toast({
+          title: 'Error al actualizar',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+      } finally {
+        actions.setLoading('searching', false);
+      }
+    }
+  }, [actions, state.filters, state.pagination?.currentPage, toast]);
+
+  const handleOpenCorrectionModal = React.useCallback(() => {
+    if (!state.selectedIds || state.selectedIds.length === 0) {
+      toast({
+        title: 'Selección requerida',
+        description: 'Debe seleccionar al menos una asistencia para corregir.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    actions.openModal();
+  }, [state.selectedIds?.length, toast, actions]);
+
+  // ============================================================================
+  // CONFIGURACIÓN DE COLUMNAS MEMOIZADA
+  // ============================================================================
+
+  const columns: Column[] = React.useMemo(
+    () => [
+      {
+        key: 'empleadoNombre',
+        label: 'Empleado',
+        sortable: true,
+        render: (item: AsistenciaRecord) => (
+          <div className='space-y-1'>
+            <div className='font-medium'>{item.empleadoNombre ?? '-'}</div>
+            <div className='text-sm text-muted-foreground'>
+              ID: {item.empleadoId ?? '-'}
+            </div>
+          </div>
+        ),
+      },
+      // Nota: El DTO actual no incluye departamento. Si se necesita, agregarlo al DTO del backend.
+      {
+        key: 'fecha',
+        label: 'Fecha',
+        sortable: true,
+        render: (item: AsistenciaRecord) => (
+          <div className='font-mono'>
+            {item.fecha
+              ? format(new Date(item.fecha), 'dd/MM/yyyy', { locale: es })
+              : '-'}
+          </div>
+        ),
+      },
+      {
+        key: 'estatusAsistenciaNombre',
+        label: 'Estatus Actual',
+        render: (item: AsistenciaRecord) => (
+          <Badge variant='outline'>{item.estatusAsistenciaNombre ?? '-'}</Badge>
+        ),
+      },
+      {
+        key: 'horarios',
+        label: 'Horarios',
+        render: (item: AsistenciaRecord) => (
+          <div className='space-y-1 text-sm'>
+            {item.horaEntradaReal && (
+              <div>
+                Entrada Real:{' '}
+                <span className='font-mono'>
+                  {item.horaEntradaReal.split(' ')[1] ?? item.horaEntradaReal}
+                </span>
+              </div>
+            )}
+            {item.horaSalidaReal && (
+              <div>
+                Salida Real:{' '}
+                <span className='font-mono'>
+                  {item.horaSalidaReal.split(' ')[1] ?? item.horaSalidaReal}
+                </span>
+              </div>
+            )}
+            {!item.horaEntradaReal && !item.horaSalidaReal && (
+              <div>
+                Programado:{' '}
+                <span className='font-mono'>
+                  {item.horaEntradaProgramada ?? '-'}
+                  {item.horaEntradaProgramada || item.horaSalidaProgramada
+                    ? ' - '
+                    : ''}
+                  {item.horaSalidaProgramada ?? '-'}
+                </span>
+              </div>
+            )}
+            {item.minutosRetardo && item.minutosRetardo > 0 && (
+              <div className='text-orange-600'>
+                Retardo: {item.minutosRetardo} min
+              </div>
+            )}
+          </div>
+        ),
+      },
+      {
+        key: 'observaciones',
+        label: 'Observaciones',
+        render: (item: AsistenciaRecord) => (
+          <div
+            className='max-w-xs truncate text-sm text-muted-foreground'
+            title={item.observaciones || undefined}
+          >
+            {item.observaciones || '-'}
+          </div>
+        ),
+      },
+    ],
+    []
+  );
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <div className='space-y-6'>
+      {/* Formulario de búsqueda */}
+      <AsistenciaSearchForm
+        filters={state.filters}
+        estatusDisponibles={state.estatusDisponibles || []}
+        loading={state.loading.searching || state.loading.loadingEstatus}
+        onSearch={handleSearch}
+        onClearFilters={handleClearFilters}
+        singleDate
+      />
+
+      {/* Error de carga de estatus */}
+      {state.errors.estatus && (
+        <Alert variant='destructive'>
+          <AlertCircle className='h-4 w-4' />
+          <AlertDescription>{state.errors.estatus}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Error de búsqueda */}
+      {state.errors.search && (
+        <Alert variant='destructive'>
+          <AlertCircle className='h-4 w-4' />
+          <AlertDescription>{state.errors.search}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Resultados de búsqueda */}
+      {state.searchResults && state.searchResults.length > 0 && (
+        <Card>
+          <CardHeader>
+            <div className='flex items-center justify-between'>
+              <CardTitle className='flex items-center gap-2'>
+                <Users className='h-5 w-5' />
+                Resultados de Búsqueda
+                <Badge variant='secondary'>
+                  {state.pagination?.total || 0} registros
+                </Badge>
+              </CardTitle>
+
+              {/* Información de selección y botón de corrección */}
+              <div className='flex items-center gap-3'>
+                {state.selectedIds && state.selectedIds.length > 0 && (
+                  <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                    <CheckCircle2 className='h-4 w-4' />
+                    {state.selectedIds.length} seleccionados
+                  </div>
+                )}
+
+                <Button
+                  onClick={handleOpenCorrectionModal}
+                  disabled={
+                    !state.selectedIds ||
+                    state.selectedIds.length === 0 ||
+                    state.loading.correcting
+                  }
+                  size='sm'
+                >
+                  {state.loading.correcting ? (
+                    <>
+                      <div className='mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent' />
+                      Procesando...
+                    </>
+                  ) : (
+                    <>
+                      <Edit3 className='mr-2 h-4 w-4' />
+                      Corregir Estatus
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <DataTableWithSelection
+              data={state.searchResults || []}
+              columns={columns}
+              currentPage={state.pagination?.currentPage || 1}
+              totalPages={state.pagination?.totalPages || 0}
+              sortField={null}
+              sortDirection='asc'
+              onSort={handleSort}
+              onPageChange={handlePageChange}
+              enableSelection={true}
+              selectedIds={state.selectedIds || []}
+              onSelectionChange={actions.setSelection}
+              getItemId={(item) => item.id}
+              emptyMessage='No se encontraron asistencias con los filtros aplicados.'
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Mensaje cuando no hay búsqueda activa */}
+      {(!state.searchResults || state.searchResults.length === 0) &&
+        Object.keys(state.filters || {}).length === 0 &&
+        !state.loading.searching && (
+          <Card>
+            <CardContent className='text-center py-12'>
+              <Users className='mx-auto h-12 w-12 text-muted-foreground mb-4' />
+              <h3 className='text-lg font-medium mb-2'>Buscar Asistencias</h3>
+              <p className='text-muted-foreground mb-4'>
+                Use los filtros de búsqueda para encontrar las asistencias que
+                desea corregir.
+              </p>
+              <p className='text-sm text-muted-foreground'>
+                Puede buscar por empleado, departamento, rango de fechas o
+                estatus actual.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+      {/* Modal de corrección de estatus */}
+      <EstatusCorrecionModal
+        open={state.modalOpen}
+        onClose={actions.closeModal}
+        asistenciasSeleccionadas={
+          state.searchResults?.filter((asistencia) =>
+            state.selectedIds.includes(asistencia.id)
+          ) || []
+        }
+        estatusDisponibles={state.estatusDisponibles || []}
+        onSuccess={handleModalSuccess}
+      />
+    </div>
+  );
+}

--- a/components/admin/CorreccionEstatusForm.tsx
+++ b/components/admin/CorreccionEstatusForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { Edit3, Users, AlertCircle, CheckCircle2 } from 'lucide-react';
@@ -14,472 +14,218 @@ import { useToast } from '@/hooks/use-toast';
 import { AsistenciaSearchForm } from './AsistenciaSearchForm';
 import { EstatusCorrecionModal } from './EstatusCorrecionModal';
 import { DataTableWithSelection } from '@/app/components/shared/data-table-with-selection';
-import { useCorreccionEstatusReducer } from '@/lib/hooks/useCorreccionEstatusReducer';
+import { useTableState } from '@/app/hooks/use-table-state';
 import {
-  buscarAsistencias,
+  buscarAsistenciasConsolidadas,
   getEstatusDisponibles,
   AsistenciaRecord,
   AsistenciaFilters,
+  EstatusDisponible,
 } from '@/lib/api/asistencia.api';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-
-// ============================================================================
-// INTERFACES
-// ============================================================================
-
-interface Column {
-  key: string;
-  label: string;
-  sortable?: boolean;
-  render?: (item: AsistenciaRecord) => React.ReactNode;
-  className?: string;
-}
-
-// ============================================================================
-// COMPONENTE PRINCIPAL
-// ============================================================================
-
 export function CorreccionEstatusForm() {
-  const { state, actions } = useCorreccionEstatusReducer();
   const { toast } = useToast();
-  const [isConfirmOpen, setConfirmOpen] = useState(false);
+  // Estado principal del componente
+  const [loading, setLoading] = useState({ estatus: true, search: false });
+  const [error, setError] = useState<string | null>(null);
+  const [estatusDisponibles, setEstatusDisponibles] = useState<
+    EstatusDisponible[]
+  >([]);
+  const [allAsistencias, setAllAsistencias] = useState<AsistenciaRecord[]>([]); // Almacena todos los resultados
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // ============================================================================
-  // EFECTOS
-  // ============================================================================
+  // Hook para manejar la paginación y ordenamiento del lado del cliente
+  const {
+    paginatedData,
+    currentPage,
+    totalPages,
+    handlePageChange,
+    handleSort,
+    sortField,
+    sortDirection,
+  } = useTableState({
+    data: allAsistencias,
+    itemsPerPage: 10,
+    defaultSortField: 'fecha',
+  });
 
-  // Cargar estatus disponibles al montar el componente
-  useEffect(() => {
-    const loadEstatusDisponibles = async () => {
-      actions.setLoading('loadingEstatus', true);
-      actions.setError('estatus', undefined);
-
-      try {
-        const estatus = await getEstatusDisponibles();
-        actions.setEstatusDisponibles(estatus);
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error
-            ? error.message
-            : 'Error al cargar estatus disponibles';
-        actions.setError('estatus', errorMessage);
-        toast({
-          title: 'Error',
-          description: errorMessage,
-          variant: 'destructive',
-        });
-      } finally {
-        actions.setLoading('loadingEstatus', false);
-      }
-    };
-
-    // Solo cargar si no hay estatus disponibles y no está cargando
-    if (
-      (!state.estatusDisponibles || state.estatusDisponibles.length === 0) &&
-      !state.loading.loadingEstatus
-    ) {
-      loadEstatusDisponibles();
+  const fetchEstatus = useCallback(async () => {
+    try {
+      setLoading((prev) => ({ ...prev, estatus: true }));
+      const estatus = await getEstatusDisponibles();
+      setEstatusDisponibles(estatus);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al cargar estatus');
+    } finally {
+      setLoading((prev) => ({ ...prev, estatus: false }));
     }
-  }, [
-    actions,
-    toast,
-    state.estatusDisponibles?.length,
-    state.loading.loadingEstatus,
-  ]);
-
-  // ============================================================================
-  // HANDLERS MEMOIZADOS
-  // ============================================================================
-
-  const handleSearch = React.useCallback(
-    async (filters: AsistenciaFilters) => {
-      actions.setLoading('searching', true);
-      actions.setError('search', undefined);
-      actions.clearSelection();
-
-      try {
-        const results = await buscarAsistencias(filters, 1, 50);
-        actions.setSearchResults(results);
-        actions.setFilters(filters);
-
-        toast({
-          title: 'Búsqueda completada',
-          description: `Se encontraron ${results.total} registros.`,
-        });
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error
-            ? error.message
-            : 'Error al buscar asistencias';
-        actions.setError('search', errorMessage);
-        toast({
-          title: 'Error en la búsqueda',
-          description: errorMessage,
-          variant: 'destructive',
-        });
-      } finally {
-        actions.setLoading('searching', false);
-      }
-    },
-    [actions, toast]
-  );
-
-  const handleClearFilters = React.useCallback(() => {
-    actions.setFilters({});
-    actions.setSearchResults({
-      asistencias: [],
-      total: 0,
-      pagina: 1,
-      totalPaginas: 0,
-    });
-    actions.clearSelection();
-    actions.clearErrors();
-  }, [actions]);
-
-  const handlePageChange = React.useCallback(
-    async (page: number) => {
-      if (Object.keys(state.filters).length === 0) return;
-
-      actions.setLoading('searching', true);
-
-      try {
-        const results = await buscarAsistencias(
-          state.filters as AsistenciaFilters,
-          page,
-          50
-        );
-        actions.setSearchResults(results);
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : 'Error al cambiar página';
-        toast({
-          title: 'Error',
-          description: errorMessage,
-          variant: 'destructive',
-        });
-      } finally {
-        actions.setLoading('searching', false);
-      }
-    },
-    [actions, state.filters, toast]
-  );
-
-  const handleSort = React.useCallback((field: string) => {
-    // TODO: Implementar ordenamiento si el backend lo soporta
-    console.log('Sort by:', field);
   }, []);
 
-  const handleModalSuccess = React.useCallback(async () => {
-    // Refrescar los resultados de búsqueda después de una corrección exitosa
-    if (Object.keys(state.filters).length > 0) {
-      actions.setLoading('searching', true);
+  useEffect(() => {
+    fetchEstatus();
+  }, [fetchEstatus]);
 
+  const handleSearch = useCallback(
+    async (filters: AsistenciaFilters) => {
+      setLoading((prev) => ({ ...prev, search: true }));
+      setError(null);
       try {
-        const results = await buscarAsistencias(
-          state.filters as AsistenciaFilters,
-          state.pagination?.currentPage || 1,
-          50
-        );
-        actions.setSearchResults(results);
-        actions.clearSelection(); // Limpiar selección después de la corrección
-
+        const results = await buscarAsistenciasConsolidadas(filters);
+        setAllAsistencias(results);
+        // Resetear la página a 1 en cada nueva búsqueda
+        handlePageChange(1);
+        setSelectedIds([]); // Limpiar selección en nueva búsqueda
         toast({
-          title: 'Datos actualizados',
-          description: 'La tabla se ha actualizado con los cambios realizados.',
+          title: 'Búsqueda completada',
+          description: `Se encontraron ${results.length} registros.`,
         });
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error
-            ? error.message
-            : 'Error al actualizar los datos';
-        toast({
-          title: 'Error al actualizar',
-          description: errorMessage,
-          variant: 'destructive',
-        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error al buscar');
+        setAllAsistencias([]);
       } finally {
-        actions.setLoading('searching', false);
+        setLoading((prev) => ({ ...prev, search: false }));
       }
-    }
-  }, [actions, state.filters, state.pagination?.currentPage, toast]);
+    },
+    [toast, handlePageChange]
+  );
 
-  const handleOpenCorrectionModal = React.useCallback(() => {
-    if (!state.selectedIds || state.selectedIds.length === 0) {
-      toast({
-        title: 'Selección requerida',
-        description: 'Debe seleccionar al menos una asistencia para corregir.',
-        variant: 'destructive',
-      });
-      return;
-    }
+  const handleClear = useCallback(() => {
+    setAllAsistencias([]);
+    setSelectedIds([]);
+    setError(null);
+  }, []);
 
-    setConfirmOpen(true);
-  }, [state.selectedIds?.length, toast]);
+  const handleModalSuccess = useCallback(() => {
+    toast({
+      title: 'Éxito',
+      description: 'Los registros han sido actualizados.',
+    });
+    // Limpiar los resultados para forzar una nueva búsqueda del usuario
+    handleClear();
+  }, [handleClear, toast]);
 
-  const handleConfirmAction = () => {
-    // Una vez confirmado, cierra el diálogo de confirmación y abre el modal de corrección
-    setConfirmOpen(false);
-    actions.openModal();
-  };
-
-  // ============================================================================
-  // CONFIGURACIÓN DE COLUMNAS MEMOIZADA
-  // ============================================================================
-
-  const columns: Column[] = React.useMemo(
+  const columns = useMemo(
     () => [
       {
         key: 'empleadoNombre',
         label: 'Empleado',
         sortable: true,
         render: (item: AsistenciaRecord) => (
-          <div className='space-y-1'>
-            <div className='font-medium'>{item.empleadoNombre ?? '-'}</div>
-            <div className='text-sm text-muted-foreground'>
-              ID: {item.empleadoId ?? '-'}
+          <div>
+            <div className='font-medium'>{item.empleadoNombre}</div>
+            <div className='text-xs text-muted-foreground'>
+              ID: {item.empleadoId}
             </div>
           </div>
         ),
       },
-      // Nota: El DTO actual no incluye departamento. Si se necesita, agregarlo al DTO del backend.
       {
         key: 'fecha',
         label: 'Fecha',
         sortable: true,
-        render: (item: AsistenciaRecord) => (
-          <div className='font-mono'>
-            {item.fecha
-              ? format(new Date(item.fecha), 'dd/MM/yyyy', { locale: es })
-              : '-'}
-          </div>
-        ),
+        render: (item: AsistenciaRecord) =>
+          format(new Date(item.fecha), 'dd/MM/yyyy', { locale: es }),
       },
       {
         key: 'estatusAsistenciaNombre',
-        label: 'Estatus Actual',
+        label: 'Estatus',
+        sortable: true,
         render: (item: AsistenciaRecord) => (
-          <Badge variant='outline'>{item.estatusAsistenciaNombre ?? '-'}</Badge>
+          <Badge variant='outline'>{item.estatusAsistenciaNombre}</Badge>
         ),
       },
       {
-        key: 'horarios',
-        label: 'Horarios',
-        render: (item: AsistenciaRecord) => (
-          <div className='space-y-1 text-sm'>
-            {item.horaEntradaReal && (
-              <div>
-                Entrada Real:{' '}
-                <span className='font-mono'>
-                  {item.horaEntradaReal.split(' ')[1] ?? item.horaEntradaReal}
-                </span>
-              </div>
-            )}
-            {item.horaSalidaReal && (
-              <div>
-                Salida Real:{' '}
-                <span className='font-mono'>
-                  {item.horaSalidaReal.split(' ')[1] ?? item.horaSalidaReal}
-                </span>
-              </div>
-            )}
-            {!item.horaEntradaReal && !item.horaSalidaReal && (
-              <div>
-                Programado:{' '}
-                <span className='font-mono'>
-                  {item.horaEntradaProgramada ?? '-'}
-                  {item.horaEntradaProgramada || item.horaSalidaProgramada
-                    ? ' - '
-                    : ''}
-                  {item.horaSalidaProgramada ?? '-'}
-                </span>
-              </div>
-            )}
-            {item.minutosRetardo && item.minutosRetardo > 0 && (
-              <div className='text-orange-600'>
-                Retardo: {item.minutosRetardo} min
-              </div>
-            )}
-          </div>
-        ),
+        key: 'horaEntradaReal',
+        label: 'Entrada Real',
+        sortable: true,
+        render: (item: AsistenciaRecord) =>
+          item.horaEntradaReal
+            ? format(new Date(item.horaEntradaReal), 'HH:mm:ss')
+            : '-',
+      },
+      {
+        key: 'horaSalidaReal',
+        label: 'Salida Real',
+        sortable: true,
+        render: (item: AsistenciaRecord) =>
+          item.horaSalidaReal
+            ? format(new Date(item.horaSalidaReal), 'HH:mm:ss')
+            : '-',
       },
       {
         key: 'observaciones',
         label: 'Observaciones',
-        render: (item: AsistenciaRecord) => (
-          <div
-            className='max-w-xs truncate text-sm text-muted-foreground'
-            title={item.observaciones || undefined}
-          >
-            {item.observaciones || '-'}
-          </div>
-        ),
+        className: 'max-w-xs truncate',
       },
     ],
     []
   );
 
-  // ============================================================================
-  // RENDER
-  // ============================================================================
-
   return (
     <div className='space-y-6'>
-      {/* Formulario de búsqueda */}
       <AsistenciaSearchForm
-        filters={state.filters}
-        estatusDisponibles={state.estatusDisponibles || []}
-        loading={state.loading.searching || state.loading.loadingEstatus}
+        estatusDisponibles={estatusDisponibles}
+        loading={loading.search || loading.estatus}
         onSearch={handleSearch}
-        onClearFilters={handleClearFilters}
-        singleDate
+        onClearFilters={handleClear}
+        showDateRange={true}
+        requireDate={true}
+        requireStatus={false}
       />
 
-      {/* Error de carga de estatus */}
-      {state.errors.estatus && (
+      {error && (
         <Alert variant='destructive'>
           <AlertCircle className='h-4 w-4' />
-          <AlertDescription>{state.errors.estatus}</AlertDescription>
+          <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
-      {/* Error de búsqueda */}
-      {state.errors.search && (
-        <Alert variant='destructive'>
-          <AlertCircle className='h-4 w-4' />
-          <AlertDescription>{state.errors.search}</AlertDescription>
-        </Alert>
-      )}
-
-      {/* Resultados de búsqueda */}
-      {state.searchResults && state.searchResults.length > 0 && (
+      {allAsistencias.length > 0 && (
         <Card>
           <CardHeader>
-            <div className='flex items-center justify-between'>
+            <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
               <CardTitle className='flex items-center gap-2'>
                 <Users className='h-5 w-5' />
-                Resultados de Búsqueda
-                <Badge variant='secondary'>
-                  {state.pagination?.total || 0} registros
-                </Badge>
+                Resultados ({allAsistencias.length})
               </CardTitle>
-
-              {/* Información de selección y botón de corrección */}
-              <div className='flex items-center gap-3'>
-                {state.selectedIds && state.selectedIds.length > 0 && (
-                  <div className='flex items-center gap-2 text-sm text-muted-foreground'>
-                    <CheckCircle2 className='h-4 w-4' />
-                    {state.selectedIds.length} seleccionados
-                  </div>
-                )}
-
-                <Button
-                  onClick={handleOpenCorrectionModal}
-                  disabled={
-                    !state.selectedIds ||
-                    state.selectedIds.length === 0 ||
-                    state.loading.correcting
-                  }
-                  size='sm'
-                >
-                  {state.loading.correcting ? (
-                    <>
-                      <div className='mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent' />
-                      Procesando...
-                    </>
-                  ) : (
-                    <>
-                      <Edit3 className='mr-2 h-4 w-4' />
-                      Corregir Estatus
-                    </>
-                  )}
-                </Button>
-              </div>
+              <Button
+                onClick={() => setIsModalOpen(true)}
+                disabled={selectedIds.length === 0}
+              >
+                <Edit3 className='mr-2 h-4 w-4' /> Corregir Estatus (
+                {selectedIds.length})
+              </Button>
             </div>
           </CardHeader>
           <CardContent>
             <DataTableWithSelection
-              data={state.searchResults || []}
+              data={paginatedData}
               columns={columns}
-              currentPage={state.pagination?.currentPage || 1}
-              totalPages={state.pagination?.totalPages || 0}
-              sortField={null}
-              sortDirection='asc'
+              currentPage={currentPage}
+              totalPages={totalPages}
+              sortField={sortField}
+              sortDirection={sortDirection}
               onSort={handleSort}
               onPageChange={handlePageChange}
-              enableSelection={true}
-              selectedIds={state.selectedIds || []}
-              onSelectionChange={actions.setSelection}
+              enableSelection
+              selectedIds={selectedIds}
+              onSelectionChange={setSelectedIds}
               getItemId={(item) => item.id}
-              emptyMessage='No se encontraron asistencias con los filtros aplicados.'
             />
           </CardContent>
         </Card>
       )}
 
-      {/* Mensaje cuando no hay búsqueda activa */}
-      {(!state.searchResults || state.searchResults.length === 0) &&
-        Object.keys(state.filters || {}).length === 0 &&
-        !state.loading.searching && (
-          <Card>
-            <CardContent className='text-center py-12'>
-              <Users className='mx-auto h-12 w-12 text-muted-foreground mb-4' />
-              <h3 className='text-lg font-medium mb-2'>Buscar Asistencias</h3>
-              <p className='text-muted-foreground mb-4'>
-                Use los filtros de búsqueda para encontrar las asistencias que
-                desea corregir.
-              </p>
-              <p className='text-sm text-muted-foreground'>
-                Puede buscar por empleado, departamento, rango de fechas o
-                estatus actual.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-
-      {/* Modal de corrección de estatus */}
       <EstatusCorrecionModal
-        open={state.modalOpen}
-        onClose={actions.closeModal}
-        asistenciasSeleccionadas={
-          state.searchResults?.filter((asistencia) =>
-            state.selectedIds.includes(asistencia.id)
-          ) || []
-        }
-        estatusDisponibles={state.estatusDisponibles || []}
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        asistenciasSeleccionadas={allAsistencias.filter((a) =>
+          selectedIds.includes(a.id)
+        )}
+        estatusDisponibles={estatusDisponibles}
         onSuccess={handleModalSuccess}
       />
-
-      {/* Diálogo de Confirmación AÑADIDO */}
-      <AlertDialog open={isConfirmOpen} onOpenChange={setConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirmar Acción</AlertDialogTitle>
-            <AlertDialogDescription>
-              ¿Está seguro de que desea proceder a corregir el estatus de los{' '}
-              <strong>{state.selectedIds?.length || 0}</strong> registros
-              seleccionados?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setConfirmOpen(false)}>
-              Cancelar
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmAction}>
-              Continuar
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/components/admin/CorreccionEstatusForm.tsx
+++ b/components/admin/CorreccionEstatusForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { Edit3, Users, AlertCircle, CheckCircle2 } from 'lucide-react';
@@ -22,6 +22,17 @@ import {
   AsistenciaFilters,
 } from '@/lib/api/asistencia.api';
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
 // ============================================================================
 // INTERFACES
 // ============================================================================
@@ -41,6 +52,7 @@ interface Column {
 export function CorreccionEstatusForm() {
   const { state, actions } = useCorreccionEstatusReducer();
   const { toast } = useToast();
+  const [isConfirmOpen, setConfirmOpen] = useState(false);
 
   // ============================================================================
   // EFECTOS
@@ -211,8 +223,14 @@ export function CorreccionEstatusForm() {
       return;
     }
 
+    setConfirmOpen(true);
+  }, [state.selectedIds?.length, toast]);
+
+  const handleConfirmAction = () => {
+    // Una vez confirmado, cierra el diálogo de confirmación y abre el modal de corrección
+    setConfirmOpen(false);
     actions.openModal();
-  }, [state.selectedIds?.length, toast, actions]);
+  };
 
   // ============================================================================
   // CONFIGURACIÓN DE COLUMNAS MEMOIZADA
@@ -440,6 +458,28 @@ export function CorreccionEstatusForm() {
         estatusDisponibles={state.estatusDisponibles || []}
         onSuccess={handleModalSuccess}
       />
+
+      {/* Diálogo de Confirmación AÑADIDO */}
+      <AlertDialog open={isConfirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmar Acción</AlertDialogTitle>
+            <AlertDialogDescription>
+              ¿Está seguro de que desea proceder a corregir el estatus de los{' '}
+              <strong>{state.selectedIds?.length || 0}</strong> registros
+              seleccionados?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmOpen(false)}>
+              Cancelar
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmAction}>
+              Continuar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/components/admin/CorreccionRegistrosForm.tsx
+++ b/components/admin/CorreccionRegistrosForm.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import {
+  Edit,
+  Users,
+  AlertCircle,
+  CheckCircle2,
+  Search,
+  X,
+} from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+import { DataTableWithSelection } from '@/app/components/shared/data-table-with-selection';
+import {
+  buscarRegistrosDetalle,
+  RegistroDetalle,
+  RegistrosDetalleResponse,
+} from '@/lib/api/registros-detalle.api';
+import { EmpleadoSimpleDTO } from '@/app/horarios/asignados/registrar/types';
+import { DepartamentoDto } from '@/lib/api/schedule-api';
+import { EmployeeSearch } from '@/app/components/shared/employee-search';
+import { DepartmentSearch } from './DepartmentSearch';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CorreccionRegistrosModal } from './CorreccionRegistrosModal';
+
+export function CorreccionRegistrosForm() {
+  const { toast } = useToast();
+  const [filters, setFilters] = useState({
+    empleado: null as EmpleadoSimpleDTO | null,
+    departamento: null as DepartamentoDto | null,
+    desde: null as Date | null,
+    hasta: null as Date | null,
+  });
+  const [data, setData] = useState<RegistrosDetalleResponse>({
+    content: [],
+    totalPages: 0,
+    totalElements: 0,
+    number: 0,
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSearch = useCallback(
+    async (page = 0) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = {
+          page,
+          size: 10,
+          empleadoId: filters.empleado?.id,
+          departamentoClave: filters.departamento?.clave,
+          desde: filters.desde
+            ? format(filters.desde, 'yyyy-MM-dd')
+            : undefined,
+          hasta: filters.hasta
+            ? format(filters.hasta, 'yyyy-MM-dd')
+            : undefined,
+        };
+        const response = await buscarRegistrosDetalle(params);
+        setData(response);
+        setSelectedIds([]); // Limpiar selección en nueva búsqueda
+      } catch (err) {
+        setError(getApiErrorMessage(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filters]
+  );
+
+  const handleClearFilters = () => {
+    setFilters({
+      empleado: null,
+      departamento: null,
+      desde: null,
+      hasta: null,
+    });
+    setData({ content: [], totalPages: 0, totalElements: 0, number: 0 });
+    setError(null);
+    setSelectedIds([]);
+  };
+
+  const handleModalSuccess = () => {
+    toast({
+      title: 'Éxito',
+      description: 'Los registros han sido actualizados.',
+    });
+    handleSearch(data.number); // Recargar la página actual
+  };
+
+  const columns = useMemo(
+    () => [
+      { key: 'id', label: 'ID', sortable: false },
+      {
+        key: 'empleadoNombre',
+        label: 'Empleado',
+        render: (item: RegistroDetalle) => (
+          <div className='font-medium'>{item.empleadoNombre}</div>
+        ),
+      },
+      {
+        key: 'fechaHora',
+        label: 'Fecha y Hora',
+        render: (item: RegistroDetalle) =>
+          format(new Date(item.fechaHora), 'dd/MM/yyyy HH:mm:ss', {
+            locale: es,
+          }),
+      },
+      {
+        key: 'tipoEoS',
+        label: 'Tipo',
+        render: (item: RegistroDetalle) => (
+          <Badge variant={item.tipoEoS === 'E' ? 'default' : 'secondary'}>
+            {item.tipoEoS === 'E' ? 'Entrada' : 'Salida'}
+          </Badge>
+        ),
+      },
+      {
+        key: 'estatusCalculado',
+        label: 'Estatus',
+        render: (item: RegistroDetalle) => (
+          <Badge variant='outline'>{item.estatusCalculado}</Badge>
+        ),
+      },
+      { key: 'tipoRegistroNombre', label: 'Fuente' },
+      {
+        key: 'observaciones',
+        label: 'Observaciones',
+        className: 'max-w-xs truncate',
+      },
+    ],
+    []
+  );
+
+  return (
+    <>
+      <Card className='mb-6'>
+        <CardHeader>
+          <CardTitle>Filtros de Búsqueda</CardTitle>
+        </CardHeader>
+        <CardContent className='space-y-4'>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+            <div className='space-y-2'>
+              <Label>Empleado</Label>
+              <EmployeeSearch
+                value={filters.empleado}
+                onChange={(emp) => setFilters((f) => ({ ...f, empleado: emp }))}
+              />
+            </div>
+            <div className='space-y-2'>
+              <Label>Departamento</Label>
+              <DepartmentSearch
+                value={filters.departamento}
+                onChange={(dep) =>
+                  setFilters((f) => ({ ...f, departamento: dep }))
+                }
+              />
+            </div>
+          </div>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+            <div className='space-y-2'>
+              <Label>Desde</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant={'outline'}
+                    className={cn(
+                      'w-full justify-start text-left font-normal',
+                      !filters.desde && 'text-muted-foreground'
+                    )}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {filters.desde ? (
+                      format(filters.desde, 'PPP', { locale: es })
+                    ) : (
+                      <span>Seleccionar fecha</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0'>
+                  <Calendar
+                    mode='single'
+                    selected={filters.desde ?? undefined}
+                    onSelect={(d) =>
+                      setFilters((f) => ({ ...f, desde: d || null }))
+                    }
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div className='space-y-2'>
+              <Label>Hasta</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant={'outline'}
+                    className={cn(
+                      'w-full justify-start text-left font-normal',
+                      !filters.hasta && 'text-muted-foreground'
+                    )}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {filters.hasta ? (
+                      format(filters.hasta, 'PPP', { locale: es })
+                    ) : (
+                      <span>Seleccionar fecha</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0'>
+                  <Calendar
+                    mode='single'
+                    selected={filters.hasta ?? undefined}
+                    onSelect={(d) =>
+                      setFilters((f) => ({ ...f, hasta: d || null }))
+                    }
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+          <div className='flex gap-2'>
+            <Button onClick={() => handleSearch(0)} disabled={loading}>
+              <Search className='mr-2 h-4 w-4' />{' '}
+              {loading ? 'Buscando...' : 'Buscar'}
+            </Button>
+            <Button variant='outline' onClick={handleClearFilters}>
+              <X className='mr-2 h-4 w-4' /> Limpiar
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Alert variant='destructive' className='mb-4'>
+          <AlertCircle className='h-4 w-4' />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <div className='flex justify-between items-center'>
+            <CardTitle className='flex items-center gap-2'>
+              <Users /> Registros Encontrados
+            </CardTitle>
+            <Button
+              onClick={() => setIsModalOpen(true)}
+              disabled={selectedIds.length === 0 || loading}
+            >
+              <Edit className='mr-2 h-4 w-4' /> Corregir Estatus (
+              {selectedIds.length})
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <DataTableWithSelection
+            data={data.content}
+            columns={columns}
+            currentPage={data.number + 1}
+            totalPages={data.totalPages}
+            onPageChange={(page) => handleSearch(page - 1)}
+            sortField={null}
+            sortDirection='asc'
+            onSort={() => {}}
+            enableSelection
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
+            getItemId={(item) => item.id}
+            emptyMessage='No se encontraron registros con los filtros aplicados.'
+          />
+        </CardContent>
+      </Card>
+
+      <CorreccionRegistrosModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSuccess={handleModalSuccess}
+        selectedIds={selectedIds}
+      />
+    </>
+  );
+}
+
+const getApiErrorMessage = (error: unknown): string => {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as any).response;
+    if (response?.data?.message) {
+      return response.data.message;
+    }
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Ocurrió un error inesperado.';
+};

--- a/components/admin/CorreccionRegistrosModal.tsx
+++ b/components/admin/CorreccionRegistrosModal.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Loader2, AlertCircle } from 'lucide-react';
+import {
+  getClavesEstatus,
+  corregirEstatusRegistros,
+} from '@/lib/api/registros-detalle.api';
+import { getApiErrorMessage } from '@/lib/api/api-helpers';
+
+interface CorreccionRegistrosModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  selectedIds: number[];
+}
+
+export function CorreccionRegistrosModal({
+  open,
+  onClose,
+  onSuccess,
+  selectedIds,
+}: CorreccionRegistrosModalProps) {
+  const [nuevoEstatus, setNuevoEstatus] = useState('');
+  const [motivo, setMotivo] = useState('');
+  const [claves, setClaves] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      const fetchClaves = async () => {
+        try {
+          const data = await getClavesEstatus();
+          setClaves(data);
+        } catch (err) {
+          setError(getApiErrorMessage(err));
+        }
+      };
+      fetchClaves();
+    } else {
+      // Reset state on close
+      setNuevoEstatus('');
+      setMotivo('');
+      setError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!nuevoEstatus || !motivo.trim()) {
+      setError('Debe seleccionar un nuevo estatus y proporcionar un motivo.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await corregirEstatusRegistros({
+        registroIds: selectedIds,
+        nuevoEstatusClave: nuevoEstatus,
+        motivo,
+      });
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(getApiErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Corregir Estatus de Registros</DialogTitle>
+          <DialogDescription>
+            Se aplicará el nuevo estatus a los {selectedIds.length} registros
+            seleccionados.
+          </DialogDescription>
+        </DialogHeader>
+        <div className='space-y-4 py-4'>
+          {error && (
+            <Alert variant='destructive'>
+              <AlertCircle className='h-4 w-4' />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className='space-y-2'>
+            <Label htmlFor='nuevo-estatus'>Nuevo Estatus</Label>
+            <Select
+              value={nuevoEstatus}
+              onValueChange={setNuevoEstatus}
+              disabled={loading}
+            >
+              <SelectTrigger id='nuevo-estatus'>
+                <SelectValue placeholder='Seleccione un estatus...' />
+              </SelectTrigger>
+              <SelectContent>
+                {claves.map((clave) => (
+                  <SelectItem key={clave} value={clave}>
+                    {clave}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='motivo'>Motivo</Label>
+            <Textarea
+              id='motivo'
+              placeholder='Describa la razón de la corrección...'
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant='outline' onClick={onClose} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={loading || !nuevoEstatus || !motivo.trim()}
+          >
+            {loading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            {loading ? 'Guardando...' : 'Guardar Cambios'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/admin/DepartmentSearch.tsx
+++ b/components/admin/DepartmentSearch.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import * as React from 'react';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { DepartamentoDto, getDepartamentos } from '@/lib/api/schedule-api';
+import { motion } from 'framer-motion';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
+
+interface DepartmentSearchProps {
+  value: DepartamentoDto | null;
+  onChange: (department: DepartamentoDto | null) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function DepartmentSearch({
+  value,
+  onChange,
+  placeholder = 'Buscar departamento...',
+  disabled = false,
+}: DepartmentSearchProps) {
+  const [open, setOpen] = React.useState(false);
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [departments, setDepartments] = React.useState<DepartamentoDto[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const fetchDepartments = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getDepartamentos();
+        setDepartments(data || []);
+      } catch (err: any) {
+        setError(err.message || 'Error al cargar departamentos');
+        setDepartments([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (open) {
+      fetchDepartments();
+    }
+  }, [open]);
+
+  const filteredDepartments = React.useMemo(() => {
+    if (!searchTerm) return departments;
+    return departments.filter(
+      (dept) =>
+        dept.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        dept.clave.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [departments, searchTerm]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant='outline'
+          role='combobox'
+          aria-expanded={open}
+          className='w-full justify-between'
+          disabled={disabled}
+        >
+          {value ? `${value.clave} - ${value.nombre}` : placeholder}
+          <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-[--radix-popover-trigger-width] p-0'>
+        <Command>
+          <CommandInput
+            placeholder='Buscar por nombre o clave...'
+            value={searchTerm}
+            onValueChange={setSearchTerm}
+          />
+          <CommandList>
+            {isLoading && (
+              <div className='flex items-center justify-center p-4'>
+                <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
+              </div>
+            )}
+            {error && (
+              <div className='p-2'>
+                <Alert variant='destructive'>
+                  <AlertCircle className='h-4 w-4' />
+                  <AlertTitle>Error de Búsqueda</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              </div>
+            )}
+            {!isLoading && !error && (
+              <>
+                <CommandEmpty>No se encontraron departamentos.</CommandEmpty>
+                <motion.div
+                  layout
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <CommandGroup>
+                    {filteredDepartments.map((department) => (
+                      <CommandItem
+                        key={department.clave}
+                        value={`${department.nombre} ${department.clave}`}
+                        onSelect={() => {
+                          onChange(department);
+                          setOpen(false);
+                        }}
+                        className='flex items-center space-x-3 p-2 cursor-pointer hover:bg-accent'
+                      >
+                        <div className='flex flex-col'>
+                          <span className='font-semibold'>
+                            {department.nombre}
+                          </span>
+                          <span className='text-xs text-zinc-500'>
+                            Clave: {department.clave}
+                          </span>
+                        </div>
+                        <Check
+                          className={cn(
+                            'ml-auto h-5 w-5',
+                            value?.clave === department.clave
+                              ? 'opacity-100'
+                              : 'opacity-0'
+                          )}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </motion.div>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/admin/EstatusCorrecionModal.tsx
+++ b/components/admin/EstatusCorrecionModal.tsx
@@ -1,0 +1,416 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { AlertTriangle, Edit3, Users, User, CheckCircle2 } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+
+import {
+  corregirEstatusIndividual,
+  corregirEstatusMasivo,
+  AsistenciaRecord,
+  EstatusDisponible,
+  EstatusCorrecionData,
+  EstatusCorrecionMasivaData,
+} from '@/lib/api/asistencia.api';
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+interface EstatusCorrecionModalProps {
+  /** Si el modal está abierto */
+  open: boolean;
+  /** Función para cerrar el modal */
+  onClose: () => void;
+  /** Asistencias seleccionadas para corregir */
+  asistenciasSeleccionadas: AsistenciaRecord[];
+  /** Lista de estatus disponibles */
+  estatusDisponibles: EstatusDisponible[];
+  /** Callback ejecutado después de una corrección exitosa */
+  onSuccess: () => void;
+}
+
+interface FormData {
+  nuevoEstatusId: string;
+  motivo: string;
+  observaciones: string;
+}
+
+// ============================================================================
+// COMPONENTE PRINCIPAL
+// ============================================================================
+
+export function EstatusCorrecionModal({
+  open,
+  onClose,
+  asistenciasSeleccionadas,
+  estatusDisponibles,
+  onSuccess,
+}: EstatusCorrecionModalProps) {
+  const { toast } = useToast();
+
+  // ============================================================================
+  // ESTADO LOCAL
+  // ============================================================================
+
+  const [formData, setFormData] = useState<FormData>({
+    nuevoEstatusId: '',
+    motivo: '',
+    observaciones: '',
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ============================================================================
+  // COMPUTED VALUES
+  // ============================================================================
+
+  const isIndividual = asistenciasSeleccionadas.length === 1;
+  const isMasivo = asistenciasSeleccionadas.length > 1;
+
+  const selectedEstatus = estatusDisponibles.find(
+    (estatus) => estatus.id.toString() === formData.nuevoEstatusId
+  );
+
+  // ============================================================================
+  // HANDLERS
+  // ============================================================================
+
+  const handleClose = useCallback(() => {
+    if (loading) return; // Prevenir cierre durante operación
+
+    // Limpiar formulario al cerrar
+    setFormData({
+      nuevoEstatusId: '',
+      motivo: '',
+      observaciones: '',
+    });
+    setError(null);
+    onClose();
+  }, [loading, onClose]);
+
+  const handleFormChange = useCallback(
+    (field: keyof FormData, value: string) => {
+      setFormData((prev) => ({
+        ...prev,
+        [field]: value,
+      }));
+
+      // Limpiar error cuando el usuario empiece a escribir
+      if (error) {
+        setError(null);
+      }
+    },
+    [error]
+  );
+
+  const validateForm = useCallback((): string | null => {
+    if (!formData.nuevoEstatusId) {
+      return 'Debe seleccionar un nuevo estatus.';
+    }
+
+    if (!formData.motivo.trim()) {
+      return 'Debe proporcionar un motivo para la corrección.';
+    }
+
+    if (formData.motivo.trim().length < 10) {
+      return 'El motivo debe tener al menos 10 caracteres.';
+    }
+
+    return null;
+  }, [formData]);
+
+  const handleSubmit = useCallback(async () => {
+    // Validar formulario
+    const validationError = validateForm();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const correctionData = {
+        nuevoEstatusId: parseInt(formData.nuevoEstatusId),
+        motivo: formData.motivo.trim(),
+        observaciones: formData.observaciones.trim() || undefined,
+      };
+
+      if (isIndividual) {
+        // Corrección individual
+        const asistencia = asistenciasSeleccionadas[0];
+        const individualData: EstatusCorrecionData = {
+          ...correctionData,
+          asistenciaId: asistencia.id, // Incluir el ID de la asistencia
+        };
+
+        await corregirEstatusIndividual(asistencia.id, individualData);
+
+        toast({
+          title: 'Corrección exitosa',
+          description: `El estatus de ${asistencia.empleadoNombre} ha sido actualizado correctamente.`,
+        });
+      } else {
+        // Corrección masiva
+        const masiveData: EstatusCorrecionMasivaData = {
+          ...correctionData,
+          asistenciaIds: asistenciasSeleccionadas.map((a) => a.id),
+        };
+
+        await corregirEstatusMasivo(masiveData);
+
+        toast({
+          title: 'Corrección masiva exitosa',
+          description: `Se actualizaron ${asistenciasSeleccionadas.length} registros de asistencia correctamente.`,
+        });
+      }
+
+      // Ejecutar callback de éxito y cerrar modal
+      onSuccess();
+      handleClose();
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Error inesperado al corregir el estatus.';
+      setError(errorMessage);
+
+      toast({
+        title: 'Error en la corrección',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    validateForm,
+    formData,
+    isIndividual,
+    asistenciasSeleccionadas,
+    toast,
+    onSuccess,
+    handleClose,
+  ]);
+
+  // ============================================================================
+  // RENDER HELPERS
+  // ============================================================================
+
+  const renderAsistenciasSummary = () => {
+    if (isIndividual) {
+      const asistencia = asistenciasSeleccionadas[0];
+      return (
+        <div className='space-y-3'>
+          <div className='flex items-center gap-2 text-sm font-medium'>
+            <User className='h-4 w-4' />
+            Corrección Individual
+          </div>
+          <div className='bg-muted/50 rounded-lg p-3 space-y-2'>
+            <div className='flex justify-between items-start'>
+              <div>
+                <div className='font-medium'>{asistencia.empleadoNombre}</div>
+                <div className='text-sm text-muted-foreground'>
+                  ID: {asistencia.empleadoId} • {asistencia.fecha}
+                </div>
+              </div>
+              <Badge variant='outline'>
+                {asistencia.estatusAsistenciaNombre}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className='space-y-3'>
+        <div className='flex items-center gap-2 text-sm font-medium'>
+          <Users className='h-4 w-4' />
+          Corrección Masiva
+        </div>
+        <div className='bg-muted/50 rounded-lg p-3'>
+          <div className='flex items-center justify-between mb-2'>
+            <span className='text-sm font-medium'>
+              {asistenciasSeleccionadas.length} registros seleccionados
+            </span>
+            <Badge variant='secondary'>{asistenciasSeleccionadas.length}</Badge>
+          </div>
+          <div className='text-xs text-muted-foreground'>
+            Se aplicará el mismo estatus y motivo a todos los registros
+            seleccionados.
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ============================================================================
+  // RENDER PRINCIPAL
+  // ============================================================================
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle className='flex items-center gap-2'>
+            <Edit3 className='h-5 w-5' />
+            Corregir Estatus de Asistencia
+          </DialogTitle>
+          <DialogDescription>
+            {isIndividual
+              ? 'Modifique el estatus de la asistencia seleccionada.'
+              : `Modifique el estatus de ${asistenciasSeleccionadas.length} asistencias seleccionadas.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          {/* Resumen de asistencias */}
+          {renderAsistenciasSummary()}
+
+          {/* Formulario de corrección */}
+          <div className='space-y-4'>
+            {/* Selección de nuevo estatus */}
+            <div className='space-y-2'>
+              <Label htmlFor='nuevo-estatus'>Nuevo Estatus *</Label>
+              <Select
+                value={formData.nuevoEstatusId}
+                onValueChange={(value) =>
+                  handleFormChange('nuevoEstatusId', value)
+                }
+                disabled={loading}
+              >
+                <SelectTrigger id='nuevo-estatus'>
+                  <SelectValue placeholder='Seleccione el nuevo estatus' />
+                </SelectTrigger>
+                <SelectContent>
+                  {estatusDisponibles.map((estatus) => (
+                    <SelectItem key={estatus.id} value={estatus.id.toString()}>
+                      <div className='flex items-center gap-2'>
+                        {estatus.color && (
+                          <div
+                            className='w-3 h-3 rounded-full'
+                            style={{ backgroundColor: estatus.color }}
+                          />
+                        )}
+                        <span>{estatus.nombre}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {selectedEstatus && (
+                <div className='text-xs text-muted-foreground'>
+                  {selectedEstatus.descripcion}
+                </div>
+              )}
+            </div>
+
+            {/* Motivo de la corrección */}
+            <div className='space-y-2'>
+              <Label htmlFor='motivo'>Motivo de la Corrección *</Label>
+              <Textarea
+                id='motivo'
+                placeholder='Explique el motivo de esta corrección (mínimo 10 caracteres)'
+                value={formData.motivo}
+                onChange={(e) => handleFormChange('motivo', e.target.value)}
+                disabled={loading}
+                rows={3}
+                className='resize-none'
+              />
+              <div className='text-xs text-muted-foreground'>
+                {formData.motivo.length}/10 caracteres mínimos
+              </div>
+            </div>
+
+            {/* Observaciones adicionales */}
+            <div className='space-y-2'>
+              <Label htmlFor='observaciones'>Observaciones Adicionales</Label>
+              <Textarea
+                id='observaciones'
+                placeholder='Observaciones adicionales (opcional)'
+                value={formData.observaciones}
+                onChange={(e) =>
+                  handleFormChange('observaciones', e.target.value)
+                }
+                disabled={loading}
+                rows={2}
+                className='resize-none'
+              />
+            </div>
+          </div>
+
+          {/* Error message */}
+          {error && (
+            <Alert variant='destructive'>
+              <AlertTriangle className='h-4 w-4' />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Advertencia para corrección masiva */}
+          {isMasivo && (
+            <Alert>
+              <AlertTriangle className='h-4 w-4' />
+              <AlertDescription>
+                <strong>Atención:</strong> Esta acción modificará{' '}
+                {asistenciasSeleccionadas.length} registros de asistencia de
+                forma simultánea. Esta operación no se puede deshacer.
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant='outline' onClick={handleClose} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              loading || !formData.nuevoEstatusId || !formData.motivo.trim()
+            }
+          >
+            {loading ? (
+              <>
+                <div className='mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent' />
+                Procesando...
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className='mr-2 h-4 w-4' />
+                {isIndividual
+                  ? 'Corregir Estatus'
+                  : `Corregir ${asistenciasSeleccionadas.length} Registros`}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/admin/JustificacionForm.tsx
+++ b/components/admin/JustificacionForm.tsx
@@ -1,14 +1,30 @@
+// components/admin/JustificacionForm.tsx
+
 'use client';
 
 import * as React from 'react';
 import { useState } from 'react';
-import { CalendarIcon, Loader2 } from 'lucide-react';
+import {
+  CalendarIcon,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  User,
+  Building,
+  Globe,
+  Send,
+} from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -24,8 +40,17 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle, CheckCircle2, Eye, ArrowRight, X } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 import { EmployeeSearch } from '@/app/components/shared/employee-search';
 import { DepartmentSearch } from './DepartmentSearch';
@@ -39,8 +64,8 @@ import {
   JustificacionDepartamentalData,
   JustificacionMasivaData,
 } from '@/lib/api/justificaciones.api';
-import { buscarAsistencias } from '@/lib/api/asistencia.api';
 import { useToast } from '@/components/ui/use-toast';
+import { getApiErrorMessage } from '@/lib/api/api-helpers';
 
 type TipoJustificacion = 'individual' | 'departamental' | 'masiva';
 
@@ -56,206 +81,128 @@ interface JustificacionFormData {
 
 interface JustificacionExitosa {
   tipo: TipoJustificacion;
-  empleadosAfectados: number;
-  fechasAfectadas: string[];
+  empleadosAfectados?: number;
+  fechasAfectadas: string;
   empleadoNombre?: string;
   departamentoNombre?: string;
 }
 
-interface JustificacionFormProps {
-  onSuccess?: () => void;
-}
+const initialState: JustificacionFormData = {
+  tipo: 'individual',
+  empleado: null,
+  departamento: null,
+  fechaInicio: null,
+  fechaFin: null,
+  fecha: null,
+  motivo: '',
+};
 
-export function JustificacionForm({ onSuccess }: JustificacionFormProps) {
+export function JustificacionForm() {
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [justificacionExitosa, setJustificacionExitosa] =
-    useState<JustificacionExitosa | null>(null);
-  const [formData, setFormData] = useState<JustificacionFormData>({
-    tipo: 'individual',
-    empleado: null,
-    departamento: null,
-    fechaInicio: null,
-    fechaFin: null,
-    fecha: null,
-    motivo: '',
-  });
+  const [error, setError] = useState<string | null>(null);
+  const [successInfo, setSuccessInfo] = useState<JustificacionExitosa | null>(
+    null
+  );
+  const [formData, setFormData] = useState<JustificacionFormData>(initialState);
+  const [isConfirmOpen, setConfirmOpen] = useState(false);
 
   const handleTipoChange = (tipo: TipoJustificacion) => {
-    setFormData({
-      ...formData,
-      tipo,
-      empleado: null,
-      departamento: null,
-      fechaInicio: null,
-      fechaFin: null,
-      fecha: null,
-      motivo: '',
-    });
-    setErrors({});
-    setJustificacionExitosa(null); // Limpiar mensaje de éxito al cambiar tipo
-  };
-
-  // Función para verificar si las asistencias fueron actualizadas
-  const verificarAsistenciasActualizadas = async (
-    fechas: string[]
-  ): Promise<{ actualizadas: number; total: number }> => {
-    try {
-      let totalActualizadas = 0;
-      let totalAsistencias = 0;
-
-      for (const fecha of fechas) {
-        // Buscar asistencias justificadas (estatus FJ = 6)
-        const asistenciasJustificadas = await buscarAsistencias(
-          {
-            fecha,
-            estatusId: 6, // FJ - Falta Justificada
-          },
-          1,
-          1000
-        );
-
-        // Buscar asistencias con faltas completas (estatus FC = 4) para comparar
-        const asistenciasFaltaCompleta = await buscarAsistencias(
-          {
-            fecha,
-            estatusId: 4, // FC - Falta Completa
-          },
-          1,
-          1000
-        );
-
-        totalActualizadas += asistenciasJustificadas.total;
-        totalAsistencias +=
-          asistenciasJustificadas.total + asistenciasFaltaCompleta.total;
-      }
-
-      return { actualizadas: totalActualizadas, total: totalAsistencias };
-    } catch (error) {
-      console.error('Error verificando asistencias actualizadas:', error);
-      return { actualizadas: 0, total: 0 };
-    }
+    setFormData({ ...initialState, tipo });
+    setError(null);
+    setSuccessInfo(null);
   };
 
   const handleDateChange = (
     field: 'fechaInicio' | 'fechaFin' | 'fecha',
     date: Date | undefined
   ) => {
-    setFormData({
-      ...formData,
-      [field]: date || null,
-    });
-
-    // Clear related errors
-    if (errors[field]) {
-      setErrors({
-        ...errors,
-        [field]: '',
-      });
-    }
+    setFormData((prev) => ({ ...prev, [field]: date || null }));
+    setError(null);
   };
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
-
-    // Validar motivo
-    if (!formData.motivo.trim()) {
-      newErrors.motivo = 'El motivo es requerido';
+    if (!formData.motivo.trim() || formData.motivo.trim().length < 10) {
+      newErrors.motivo =
+        'El motivo es requerido y debe tener al menos 10 caracteres.';
     }
-
-    // Validaciones específicas por tipo
     switch (formData.tipo) {
       case 'individual':
-        if (!formData.empleado) {
-          newErrors.empleado = 'Debe seleccionar un empleado';
-        }
-        if (!formData.fechaInicio) {
-          newErrors.fechaInicio = 'La fecha de inicio es requerida';
-        }
-        if (!formData.fechaFin) {
-          newErrors.fechaFin = 'La fecha de fin es requerida';
-        }
+        if (!formData.empleado)
+          newErrors.empleado = 'Debe seleccionar un empleado.';
+        if (!formData.fechaInicio)
+          newErrors.fechaInicio = 'La fecha de inicio es requerida.';
         if (
           formData.fechaInicio &&
           formData.fechaFin &&
           formData.fechaFin < formData.fechaInicio
         ) {
           newErrors.fechaFin =
-            'La fecha de fin debe ser posterior a la fecha de inicio';
+            'La fecha de fin debe ser posterior a la de inicio.';
         }
         break;
-
       case 'departamental':
-        if (!formData.departamento) {
-          newErrors.departamento = 'Debe seleccionar un departamento';
-        }
-        if (!formData.fecha) {
-          newErrors.fecha = 'La fecha es requerida';
-        }
+        if (!formData.departamento)
+          newErrors.departamento = 'Debe seleccionar un departamento.';
+        if (!formData.fecha) newErrors.fecha = 'La fecha es requerida.';
         break;
-
       case 'masiva':
-        if (!formData.fecha) {
-          newErrors.fecha = 'La fecha es requerida';
-        }
+        if (!formData.fecha) newErrors.fecha = 'La fecha es requerida.';
         break;
     }
-
-    setErrors(newErrors);
+    setError(Object.values(newErrors).join(' '));
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!validateForm()) {
-      return;
+    setSuccessInfo(null);
+    if (validateForm()) {
+      setConfirmOpen(true);
     }
+  };
 
+  const handleConfirmSubmit = async () => {
     setLoading(true);
-    setErrors({});
+    setError(null);
+    setConfirmOpen(false);
 
     try {
       let response: any;
-      let empleadosAfectados = 0;
-      let fechasAfectadas: string[] = [];
+      let successPayload: Partial<JustificacionExitosa> = {
+        tipo: formData.tipo,
+      };
 
       switch (formData.tipo) {
         case 'individual':
           const individualData: JustificacionIndividualData = {
             empleadoId: formData.empleado!.id,
             fechaInicio: format(formData.fechaInicio!, 'yyyy-MM-dd'),
-            fechaFin: format(formData.fechaFin!, 'yyyy-MM-dd'),
+            fechaFin: format(
+              formData.fechaFin || formData.fechaInicio!,
+              'yyyy-MM-dd'
+            ),
             motivo: formData.motivo.trim(),
           };
           response = await createJustificacionIndividual(individualData);
-          empleadosAfectados = 1;
-
-          // Calcular fechas afectadas para justificación individual
-          const fechaInicio = new Date(formData.fechaInicio!);
-          const fechaFin = new Date(formData.fechaFin!);
-          const fechasRango: string[] = [];
-          for (
-            let d = new Date(fechaInicio);
-            d <= fechaFin;
-            d.setDate(d.getDate() + 1)
-          ) {
-            fechasRango.push(format(d, 'yyyy-MM-dd'));
-          }
-          fechasAfectadas = fechasRango;
+          successPayload.empleadoNombre = formData.empleado?.nombreCompleto;
+          successPayload.fechasAfectadas = `${format(formData.fechaInicio!, 'dd/MM/yyyy')} - ${format(formData.fechaFin || formData.fechaInicio!, 'dd/MM/yyyy')}`;
           break;
 
         case 'departamental':
           const departamentalData: JustificacionDepartamentalData = {
-            departamentoId: parseInt(formData.departamento!.clave, 10), // Using clave as the ID
+            departamentoClave: formData.departamento!.clave,
             fecha: format(formData.fecha!, 'yyyy-MM-dd'),
             motivo: formData.motivo.trim(),
           };
           response = await createJustificacionDepartamental(departamentalData);
-          empleadosAfectados =
-            response.empleadosJustificados || response.empleadosAfectados || 0;
-          fechasAfectadas = [format(formData.fecha!, 'yyyy-MM-dd')];
+          successPayload.departamentoNombre = formData.departamento?.nombre;
+          successPayload.fechasAfectadas = format(
+            formData.fecha!,
+            'dd/MM/yyyy'
+          );
+          successPayload.empleadosAfectados = response.empleadosAfectados;
           break;
 
         case 'masiva':
@@ -263,72 +210,26 @@ export function JustificacionForm({ onSuccess }: JustificacionFormProps) {
             fecha: format(formData.fecha!, 'yyyy-MM-dd'),
             motivo: formData.motivo.trim(),
           };
-          console.log('Enviando justificación masiva:', masivaData); // Debug log
           response = await createJustificacionMasiva(masivaData);
-          console.log('Respuesta del backend:', response); // Debug log
-          empleadosAfectados =
-            response.empleadosJustificados || response.empleadosAfectados || 0;
-          fechasAfectadas = [format(formData.fecha!, 'yyyy-MM-dd')];
+          successPayload.fechasAfectadas = format(
+            formData.fecha!,
+            'dd/MM/yyyy'
+          );
+          successPayload.empleadosAfectados = response.empleadosAfectados;
           break;
       }
 
-      // Verificar si las asistencias fueron realmente actualizadas
-      const verificacion =
-        await verificarAsistenciasActualizadas(fechasAfectadas);
-
-      // Toast mejorado con información detallada
-      const fechasTexto =
-        fechasAfectadas.length === 1
-          ? format(new Date(fechasAfectadas[0]), 'dd/MM/yyyy', { locale: es })
-          : fechasAfectadas.length > 1
-            ? `${format(new Date(fechasAfectadas[0]), 'dd/MM/yyyy', { locale: es })} - ${format(new Date(fechasAfectadas[fechasAfectadas.length - 1]), 'dd/MM/yyyy', { locale: es })}`
-            : 'fechas seleccionadas';
-
-      // Determinar si hay problemas con la actualización
-      const hayProblemas =
-        verificacion.actualizadas === 0 && empleadosAfectados > 0;
-
-      const descripcionDetallada = hayProblemas
-        ? `⚠️ ADVERTENCIA: La justificación se creó pero las asistencias NO fueron actualizadas automáticamente. Verifique manualmente en "Corrección de Estatus".`
-        : empleadosAfectados > 0
-          ? `Justificación procesada exitosamente. ${empleadosAfectados} empleado${empleadosAfectados > 1 ? 's' : ''} afectado${empleadosAfectados > 1 ? 's' : ''} para ${fechasTexto}. ${verificacion.actualizadas} asistencias actualizadas.`
-          : `Justificación procesada exitosamente para ${fechasTexto}. ${verificacion.actualizadas} asistencias actualizadas.`;
-
+      setSuccessInfo(successPayload as JustificacionExitosa);
       toast({
-        title: hayProblemas
-          ? 'Justificación creada con advertencias'
-          : 'Justificación creada exitosamente',
-        description: descripcionDetallada,
-        duration: hayProblemas ? 10000 : 6000, // Más tiempo si hay problemas
-        variant: hayProblemas ? 'destructive' : 'default',
+        title: 'Justificación Creada',
+        description: 'La operación se completó exitosamente.',
       });
-
-      // Guardar información de la justificación exitosa para mostrar el alert
-      setJustificacionExitosa({
-        tipo: formData.tipo,
-        empleadosAfectados,
-        fechasAfectadas,
-        empleadoNombre: formData.empleado?.nombreCompleto,
-        departamentoNombre: formData.departamento?.nombre,
-      });
-
-      // Reset form
-      setFormData({
-        tipo: 'individual',
-        empleado: null,
-        departamento: null,
-        fechaInicio: null,
-        fechaFin: null,
-        fecha: null,
-        motivo: '',
-      });
-
-      onSuccess?.();
-    } catch (error: any) {
+      setFormData(initialState);
+    } catch (err) {
+      setError(getApiErrorMessage(err));
       toast({
-        title: 'Error al procesar justificación',
-        description:
-          error.message || 'Ocurrió un error al procesar la justificación',
+        title: 'Error',
+        description: getApiErrorMessage(err),
         variant: 'destructive',
       });
     } finally {
@@ -336,278 +237,268 @@ export function JustificacionForm({ onSuccess }: JustificacionFormProps) {
     }
   };
 
-  const renderDateFields = () => {
+  // --- INICIO DE LA CORRECCIÓN ---
+  const getConfirmationDescription = () => {
+    // Se agregan validaciones para asegurar que las fechas no sean nulas antes de formatear
     switch (formData.tipo) {
       case 'individual':
-        return (
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-            <div className='space-y-2'>
-              <Label htmlFor='fechaInicio'>Fecha de Inicio</Label>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant='outline'
-                    className='w-full justify-start text-left font-normal'
-                    disabled={loading}
-                  >
-                    <CalendarIcon className='mr-2 h-4 w-4' />
-                    {formData.fechaInicio ? (
-                      format(formData.fechaInicio, 'PPP', { locale: es })
-                    ) : (
-                      <span>Seleccione fecha de inicio</span>
-                    )}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className='w-auto p-0'>
-                  <Calendar
-                    mode='single'
-                    selected={formData.fechaInicio ?? undefined}
-                    onSelect={(date) => handleDateChange('fechaInicio', date)}
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
-              {errors.fechaInicio && (
-                <p className='text-sm text-destructive'>{errors.fechaInicio}</p>
-              )}
-            </div>
-
-            <div className='space-y-2'>
-              <Label htmlFor='fechaFin'>Fecha de Fin</Label>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant='outline'
-                    className='w-full justify-start text-left font-normal'
-                    disabled={loading}
-                  >
-                    <CalendarIcon className='mr-2 h-4 w-4' />
-                    {formData.fechaFin ? (
-                      format(formData.fechaFin, 'PPP', { locale: es })
-                    ) : (
-                      <span>Seleccione fecha de fin</span>
-                    )}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className='w-auto p-0'>
-                  <Calendar
-                    mode='single'
-                    selected={formData.fechaFin ?? undefined}
-                    onSelect={(date) => handleDateChange('fechaFin', date)}
-                    disabled={{ before: formData.fechaInicio ?? new Date(0) }}
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
-              {errors.fechaFin && (
-                <p className='text-sm text-destructive'>{errors.fechaFin}</p>
-              )}
-            </div>
-          </div>
-        );
+        if (formData.empleado && formData.fechaInicio) {
+          const startDate = format(formData.fechaInicio, 'PPP', { locale: es });
+          const endDate = format(
+            formData.fechaFin || formData.fechaInicio,
+            'PPP',
+            { locale: es }
+          );
+          return `Se creará una justificación para el empleado ${formData.empleado.nombreCompleto} desde el ${startDate} hasta el ${endDate}.`;
+        }
+        return 'Por favor, complete los detalles de la justificación individual.';
 
       case 'departamental':
+        if (formData.departamento && formData.fecha) {
+          return `Se creará una justificación para TODOS los empleados del departamento ${formData.departamento.nombre} para la fecha ${format(formData.fecha, 'PPP', { locale: es })}.`;
+        }
+        return 'Por favor, complete los detalles de la justificación departamental.';
+
       case 'masiva':
-        return (
-          <div className='space-y-2'>
-            <Label htmlFor='fecha'>Fecha</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant='outline'
-                  className='w-full justify-start text-left font-normal'
-                  disabled={loading}
-                >
-                  <CalendarIcon className='mr-2 h-4 w-4' />
-                  {formData.fecha ? (
-                    format(formData.fecha, 'PPP', { locale: es })
-                  ) : (
-                    <span>Seleccione fecha</span>
-                  )}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className='w-auto p-0'>
-                <Calendar
-                  mode='single'
-                  selected={formData.fecha ?? undefined}
-                  onSelect={(date) => handleDateChange('fecha', date)}
-                  initialFocus
-                />
-              </PopoverContent>
-            </Popover>
-            {errors.fecha && (
-              <p className='text-sm text-destructive'>{errors.fecha}</p>
-            )}
-          </div>
-        );
+        if (formData.fecha) {
+          return `Se creará una justificación masiva para TODOS los empleados del sistema para la fecha ${format(formData.fecha, 'PPP', { locale: es })}. Esta acción es de alto impacto.`;
+        }
+        return 'Por favor, complete los detalles de la justificación masiva.';
 
       default:
-        return null;
+        return '¿Está seguro de realizar esta acción?';
     }
   };
-
-  const renderJustificacionExitosaAlert = () => {
-    if (!justificacionExitosa) return null;
-
-    const fechasTexto =
-      justificacionExitosa.fechasAfectadas.length === 1
-        ? format(
-            new Date(justificacionExitosa.fechasAfectadas[0]),
-            'dd/MM/yyyy',
-            { locale: es }
-          )
-        : justificacionExitosa.fechasAfectadas.length > 1
-          ? `${format(new Date(justificacionExitosa.fechasAfectadas[0]), 'dd/MM/yyyy', { locale: es })} - ${format(new Date(justificacionExitosa.fechasAfectadas[justificacionExitosa.fechasAfectadas.length - 1]), 'dd/MM/yyyy', { locale: es })}`
-          : 'fechas seleccionadas';
-
-    let detalleAfectados = '';
-    switch (justificacionExitosa.tipo) {
-      case 'individual':
-        detalleAfectados = `Empleado: ${justificacionExitosa.empleadoNombre}`;
-        break;
-      case 'departamental':
-        detalleAfectados = `Departamento: ${justificacionExitosa.departamentoNombre} (${justificacionExitosa.empleadosAfectados} empleados)`;
-        break;
-      case 'masiva':
-        detalleAfectados = `Todos los empleados del sistema (${justificacionExitosa.empleadosAfectados} empleados)`;
-        break;
-    }
-
-    return (
-      <Alert className='border-green-200 bg-green-50 relative'>
-        <CheckCircle2 className='h-4 w-4 text-green-600' />
-        <Button
-          variant='ghost'
-          size='icon'
-          className='absolute top-2 right-2 h-6 w-6 text-green-600 hover:text-green-800 hover:bg-green-100'
-          onClick={() => setJustificacionExitosa(null)}
-        >
-          <X className='h-4 w-4' />
-        </Button>
-        <AlertDescription className='text-green-800 pr-8'>
-          <div className='space-y-2'>
-            <div className='font-medium'>
-              ✅ Justificación procesada exitosamente
-            </div>
-            <div className='text-sm space-y-1'>
-              <div>
-                <strong>Fechas afectadas:</strong> {fechasTexto}
-              </div>
-              <div>
-                <strong>Personal afectado:</strong> {detalleAfectados}
-              </div>
-            </div>
-            <div className='flex items-center gap-2 text-sm pt-2 border-t border-green-200'>
-              <Eye className='h-4 w-4' />
-              <span>
-                Para verificar las asistencias actualizadas, vaya a la pestaña
-              </span>
-              <strong>"Corrección de Estatus"</strong>
-              <ArrowRight className='h-4 w-4' />
-            </div>
-          </div>
-        </AlertDescription>
-      </Alert>
-    );
-  };
+  // --- FIN DE LA CORRECCIÓN ---
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Crear Justificación</CardTitle>
-      </CardHeader>
-      <CardContent>
-        {/* Alert de justificación exitosa */}
-        {renderJustificacionExitosaAlert()}
-
-        <form
-          onSubmit={handleSubmit}
-          className={`space-y-6 ${justificacionExitosa ? 'mt-6' : ''}`}
-        >
-          {/* Tipo de Justificación */}
-          <div className='space-y-2'>
-            <Label htmlFor='tipo'>Tipo de Justificación</Label>
-            <Select
-              value={formData.tipo}
-              onValueChange={(value: TipoJustificacion) =>
-                handleTipoChange(value)
-              }
-              disabled={loading}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder='Seleccione el tipo' />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='individual'>Individual</SelectItem>
-                <SelectItem value='departamental'>Departamental</SelectItem>
-                <SelectItem value='masiva'>Masiva</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Campos específicos por tipo */}
-          {formData.tipo === 'individual' && (
-            <div className='space-y-2'>
-              <Label htmlFor='empleado'>Empleado</Label>
-              <EmployeeSearch
-                value={formData.empleado}
-                onChange={(empleado) => setFormData({ ...formData, empleado })}
-                disabled={loading}
-                placeholder='Buscar empleado por nombre, RFC o CURP...'
-              />
-              {errors.empleado && (
-                <p className='text-sm text-destructive'>{errors.empleado}</p>
-              )}
-            </div>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Crear Justificación</CardTitle>
+          <CardDescription>
+            Seleccione el tipo de justificación y complete los campos
+            requeridos.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant='destructive' className='mb-4'>
+              <AlertCircle className='h-4 w-4' />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
           )}
 
-          {formData.tipo === 'departamental' && (
+          {successInfo && (
+            <Alert className='mb-4 border-green-500/50 text-green-700 dark:text-green-400 [&>svg]:text-green-700 dark:[&>svg]:text-green-400'>
+              <CheckCircle2 className='h-4 w-4' />
+              <AlertTitle>¡Completado!</AlertTitle>
+              <AlertDescription>
+                Justificación de tipo <strong>{successInfo.tipo}</strong> creada
+                para las fechas <strong>{successInfo.fechasAfectadas}</strong>.
+                {successInfo.empleadoNombre &&
+                  ` Empleado: ${successInfo.empleadoNombre}.`}
+                {successInfo.departamentoNombre &&
+                  ` Departamento: ${successInfo.departamentoNombre}.`}
+                {typeof successInfo.empleadosAfectados !== 'undefined' &&
+                  ` Empleados afectados: ${successInfo.empleadosAfectados}.`}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <form onSubmit={handleSubmit} className='space-y-6'>
             <div className='space-y-2'>
-              <Label htmlFor='departamento'>Departamento</Label>
-              <DepartmentSearch
-                value={formData.departamento}
-                onChange={(departamento) =>
-                  setFormData({ ...formData, departamento })
+              <Label>Tipo de Justificación</Label>
+              <Select
+                value={formData.tipo}
+                onValueChange={(v) => handleTipoChange(v as TipoJustificacion)}
+                disabled={loading}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder='Seleccione el tipo' />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='individual'>
+                    <div className='flex items-center gap-2'>
+                      <User /> Individual
+                    </div>
+                  </SelectItem>
+                  <SelectItem value='departamental'>
+                    <div className='flex items-center gap-2'>
+                      <Building /> Departamental
+                    </div>
+                  </SelectItem>
+                  <SelectItem value='masiva'>
+                    <div className='flex items-center gap-2'>
+                      <Globe /> Masiva
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {formData.tipo === 'individual' && (
+              <div className='space-y-2'>
+                <Label>Empleado</Label>
+                <EmployeeSearch
+                  value={formData.empleado}
+                  onChange={(emp) =>
+                    setFormData((f) => ({ ...f, empleado: emp }))
+                  }
+                  disabled={loading}
+                />
+              </div>
+            )}
+
+            {formData.tipo === 'departamental' && (
+              <div className='space-y-2'>
+                <Label>Departamento</Label>
+                <DepartmentSearch
+                  value={formData.departamento}
+                  onChange={(dep) =>
+                    setFormData((f) => ({ ...f, departamento: dep }))
+                  }
+                  disabled={loading}
+                />
+              </div>
+            )}
+
+            {formData.tipo === 'individual' ? (
+              <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+                <div className='space-y-2'>
+                  <Label>Fecha de Inicio</Label>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant='outline'
+                        className='w-full justify-start text-left font-normal'
+                        disabled={loading}
+                      >
+                        <CalendarIcon className='mr-2 h-4 w-4' />
+                        {formData.fechaInicio ? (
+                          format(formData.fechaInicio, 'PPP', { locale: es })
+                        ) : (
+                          <span>Seleccione fecha</span>
+                        )}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className='w-auto p-0'>
+                      <Calendar
+                        mode='single'
+                        selected={formData.fechaInicio ?? undefined}
+                        onSelect={(d) => handleDateChange('fechaInicio', d)}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div className='space-y-2'>
+                  <Label>Fecha de Fin (Opcional)</Label>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant='outline'
+                        className='w-full justify-start text-left font-normal'
+                        disabled={loading}
+                      >
+                        <CalendarIcon className='mr-2 h-4 w-4' />
+                        {formData.fechaFin ? (
+                          format(formData.fechaFin, 'PPP', { locale: es })
+                        ) : (
+                          <span>Igual a fecha de inicio</span>
+                        )}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className='w-auto p-0'>
+                      <Calendar
+                        mode='single'
+                        selected={formData.fechaFin ?? undefined}
+                        onSelect={(d) => handleDateChange('fechaFin', d)}
+                        disabled={{
+                          before: formData.fechaInicio ?? new Date(0),
+                        }}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </div>
+            ) : (
+              <div className='space-y-2'>
+                <Label>Fecha</Label>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant='outline'
+                      className='w-full justify-start text-left font-normal'
+                      disabled={loading}
+                    >
+                      <CalendarIcon className='mr-2 h-4 w-4' />
+                      {formData.fecha ? (
+                        format(formData.fecha, 'PPP', { locale: es })
+                      ) : (
+                        <span>Seleccione fecha</span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className='w-auto p-0'>
+                    <Calendar
+                      mode='single'
+                      selected={formData.fecha ?? undefined}
+                      onSelect={(d) => handleDateChange('fecha', d)}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+              </div>
+            )}
+
+            <div className='space-y-2'>
+              <Label>Motivo</Label>
+              <Textarea
+                placeholder='Describa el motivo de la justificación (mínimo 10 caracteres)'
+                value={formData.motivo}
+                onChange={(e) =>
+                  setFormData((f) => ({ ...f, motivo: e.target.value }))
                 }
                 disabled={loading}
-                placeholder='Buscar departamento...'
+                rows={3}
               />
-              {errors.departamento && (
-                <p className='text-sm text-destructive'>
-                  {errors.departamento}
-                </p>
-              )}
             </div>
-          )}
 
-          {/* Campos de fecha */}
-          {renderDateFields()}
+            <Button type='submit' disabled={loading} className='w-full'>
+              {loading ? (
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              ) : (
+                <Send className='mr-2 h-4 w-4' />
+              )}
+              {loading ? 'Procesando...' : 'Crear Justificación'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
-          {/* Motivo */}
-          <div className='space-y-2'>
-            <Label htmlFor='motivo'>Motivo</Label>
-            <Textarea
-              id='motivo'
-              placeholder='Ingrese el motivo de la justificación...'
-              value={formData.motivo}
-              onChange={(e) =>
-                setFormData({ ...formData, motivo: e.target.value })
-              }
-              disabled={loading}
-              rows={3}
-            />
-            {errors.motivo && (
-              <p className='text-sm text-destructive'>{errors.motivo}</p>
-            )}
-          </div>
-
-          {/* Botón de envío */}
-          <Button type='submit' disabled={loading} className='w-full'>
-            {loading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
-            {loading ? 'Procesando...' : 'Crear Justificación'}
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
+      <AlertDialog open={isConfirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Está seguro?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {getConfirmationDescription()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={loading}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmSubmit} disabled={loading}>
+              {loading ? (
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              ) : (
+                'Confirmar'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/components/admin/JustificacionForm.tsx
+++ b/components/admin/JustificacionForm.tsx
@@ -1,0 +1,428 @@
+'use client';
+
+import * as React from 'react';
+import { useState } from 'react';
+import { CalendarIcon, Loader2 } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
+
+import { EmployeeSearch } from '@/app/components/shared/employee-search';
+import { DepartmentSearch } from './DepartmentSearch';
+import { EmpleadoSimpleDTO } from '@/app/horarios/asignados/registrar/types';
+import { DepartamentoDto } from '@/lib/api/schedule-api';
+import {
+  createJustificacionIndividual,
+  createJustificacionDepartamental,
+  createJustificacionMasiva,
+  JustificacionIndividualData,
+  JustificacionDepartamentalData,
+  JustificacionMasivaData,
+} from '@/lib/api/justificaciones.api';
+import { useToast } from '@/components/ui/use-toast';
+
+type TipoJustificacion = 'individual' | 'departamental' | 'masiva';
+
+interface JustificacionFormData {
+  tipo: TipoJustificacion;
+  empleado: EmpleadoSimpleDTO | null;
+  departamento: DepartamentoDto | null;
+  fechaInicio: Date | null;
+  fechaFin: Date | null;
+  fecha: Date | null;
+  motivo: string;
+}
+
+interface JustificacionFormProps {
+  onSuccess?: () => void;
+}
+
+export function JustificacionForm({ onSuccess }: JustificacionFormProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formData, setFormData] = useState<JustificacionFormData>({
+    tipo: 'individual',
+    empleado: null,
+    departamento: null,
+    fechaInicio: null,
+    fechaFin: null,
+    fecha: null,
+    motivo: '',
+  });
+
+  const handleTipoChange = (tipo: TipoJustificacion) => {
+    setFormData({
+      ...formData,
+      tipo,
+      empleado: null,
+      departamento: null,
+      fechaInicio: null,
+      fechaFin: null,
+      fecha: null,
+      motivo: '',
+    });
+    setErrors({});
+  };
+
+  const handleDateChange = (
+    field: 'fechaInicio' | 'fechaFin' | 'fecha',
+    date: Date | undefined
+  ) => {
+    setFormData({
+      ...formData,
+      [field]: date || null,
+    });
+
+    // Clear related errors
+    if (errors[field]) {
+      setErrors({
+        ...errors,
+        [field]: '',
+      });
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // Validar motivo
+    if (!formData.motivo.trim()) {
+      newErrors.motivo = 'El motivo es requerido';
+    }
+
+    // Validaciones específicas por tipo
+    switch (formData.tipo) {
+      case 'individual':
+        if (!formData.empleado) {
+          newErrors.empleado = 'Debe seleccionar un empleado';
+        }
+        if (!formData.fechaInicio) {
+          newErrors.fechaInicio = 'La fecha de inicio es requerida';
+        }
+        if (!formData.fechaFin) {
+          newErrors.fechaFin = 'La fecha de fin es requerida';
+        }
+        if (
+          formData.fechaInicio &&
+          formData.fechaFin &&
+          formData.fechaFin < formData.fechaInicio
+        ) {
+          newErrors.fechaFin =
+            'La fecha de fin debe ser posterior a la fecha de inicio';
+        }
+        break;
+
+      case 'departamental':
+        if (!formData.departamento) {
+          newErrors.departamento = 'Debe seleccionar un departamento';
+        }
+        if (!formData.fecha) {
+          newErrors.fecha = 'La fecha es requerida';
+        }
+        break;
+
+      case 'masiva':
+        if (!formData.fecha) {
+          newErrors.fecha = 'La fecha es requerida';
+        }
+        break;
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setLoading(true);
+    setErrors({});
+
+    try {
+      switch (formData.tipo) {
+        case 'individual':
+          const individualData: JustificacionIndividualData = {
+            empleadoId: formData.empleado!.id,
+            fechaInicio: format(formData.fechaInicio!, 'yyyy-MM-dd'),
+            fechaFin: format(formData.fechaFin!, 'yyyy-MM-dd'),
+            motivo: formData.motivo.trim(),
+          };
+          await createJustificacionIndividual(individualData);
+          break;
+
+        case 'departamental':
+          const departamentalData: JustificacionDepartamentalData = {
+            departamentoId: parseInt(formData.departamento!.clave, 10), // Using clave as the ID
+            fecha: format(formData.fecha!, 'yyyy-MM-dd'),
+            motivo: formData.motivo.trim(),
+          };
+          await createJustificacionDepartamental(departamentalData);
+          break;
+
+        case 'masiva':
+          const masivaData: JustificacionMasivaData = {
+            fecha: format(formData.fecha!, 'yyyy-MM-dd'),
+            motivo: formData.motivo.trim(),
+          };
+          await createJustificacionMasiva(masivaData);
+          break;
+      }
+
+      toast({
+        title: 'Justificación creada',
+        description: 'La justificación se ha procesado correctamente.',
+      });
+
+      // Reset form
+      setFormData({
+        tipo: 'individual',
+        empleado: null,
+        departamento: null,
+        fechaInicio: null,
+        fechaFin: null,
+        fecha: null,
+        motivo: '',
+      });
+
+      onSuccess?.();
+    } catch (error: any) {
+      toast({
+        title: 'Error',
+        description:
+          error.message || 'Ocurrió un error al procesar la justificación',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderDateFields = () => {
+    switch (formData.tipo) {
+      case 'individual':
+        return (
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='fechaInicio'>Fecha de Inicio</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant='outline'
+                    className='w-full justify-start text-left font-normal'
+                    disabled={loading}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {formData.fechaInicio ? (
+                      format(formData.fechaInicio, 'PPP', { locale: es })
+                    ) : (
+                      <span>Seleccione fecha de inicio</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0'>
+                  <Calendar
+                    mode='single'
+                    selected={formData.fechaInicio ?? undefined}
+                    onSelect={(date) => handleDateChange('fechaInicio', date)}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+              {errors.fechaInicio && (
+                <p className='text-sm text-destructive'>{errors.fechaInicio}</p>
+              )}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='fechaFin'>Fecha de Fin</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant='outline'
+                    className='w-full justify-start text-left font-normal'
+                    disabled={loading}
+                  >
+                    <CalendarIcon className='mr-2 h-4 w-4' />
+                    {formData.fechaFin ? (
+                      format(formData.fechaFin, 'PPP', { locale: es })
+                    ) : (
+                      <span>Seleccione fecha de fin</span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className='w-auto p-0'>
+                  <Calendar
+                    mode='single'
+                    selected={formData.fechaFin ?? undefined}
+                    onSelect={(date) => handleDateChange('fechaFin', date)}
+                    disabled={{ before: formData.fechaInicio ?? new Date(0) }}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+              {errors.fechaFin && (
+                <p className='text-sm text-destructive'>{errors.fechaFin}</p>
+              )}
+            </div>
+          </div>
+        );
+
+      case 'departamental':
+      case 'masiva':
+        return (
+          <div className='space-y-2'>
+            <Label htmlFor='fecha'>Fecha</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant='outline'
+                  className='w-full justify-start text-left font-normal'
+                  disabled={loading}
+                >
+                  <CalendarIcon className='mr-2 h-4 w-4' />
+                  {formData.fecha ? (
+                    format(formData.fecha, 'PPP', { locale: es })
+                  ) : (
+                    <span>Seleccione fecha</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className='w-auto p-0'>
+                <Calendar
+                  mode='single'
+                  selected={formData.fecha ?? undefined}
+                  onSelect={(date) => handleDateChange('fecha', date)}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+            {errors.fecha && (
+              <p className='text-sm text-destructive'>{errors.fecha}</p>
+            )}
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Crear Justificación</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className='space-y-6'>
+          {/* Tipo de Justificación */}
+          <div className='space-y-2'>
+            <Label htmlFor='tipo'>Tipo de Justificación</Label>
+            <Select
+              value={formData.tipo}
+              onValueChange={(value: TipoJustificacion) =>
+                handleTipoChange(value)
+              }
+              disabled={loading}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder='Seleccione el tipo' />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='individual'>Individual</SelectItem>
+                <SelectItem value='departamental'>Departamental</SelectItem>
+                <SelectItem value='masiva'>Masiva</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Campos específicos por tipo */}
+          {formData.tipo === 'individual' && (
+            <div className='space-y-2'>
+              <Label htmlFor='empleado'>Empleado</Label>
+              <EmployeeSearch
+                value={formData.empleado}
+                onChange={(empleado) => setFormData({ ...formData, empleado })}
+                disabled={loading}
+                placeholder='Buscar empleado por nombre, RFC o CURP...'
+              />
+              {errors.empleado && (
+                <p className='text-sm text-destructive'>{errors.empleado}</p>
+              )}
+            </div>
+          )}
+
+          {formData.tipo === 'departamental' && (
+            <div className='space-y-2'>
+              <Label htmlFor='departamento'>Departamento</Label>
+              <DepartmentSearch
+                value={formData.departamento}
+                onChange={(departamento) =>
+                  setFormData({ ...formData, departamento })
+                }
+                disabled={loading}
+                placeholder='Buscar departamento...'
+              />
+              {errors.departamento && (
+                <p className='text-sm text-destructive'>
+                  {errors.departamento}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Campos de fecha */}
+          {renderDateFields()}
+
+          {/* Motivo */}
+          <div className='space-y-2'>
+            <Label htmlFor='motivo'>Motivo</Label>
+            <Textarea
+              id='motivo'
+              placeholder='Ingrese el motivo de la justificación...'
+              value={formData.motivo}
+              onChange={(e) =>
+                setFormData({ ...formData, motivo: e.target.value })
+              }
+              disabled={loading}
+              rows={3}
+            />
+            {errors.motivo && (
+              <p className='text-sm text-destructive'>{errors.motivo}</p>
+            )}
+          </div>
+
+          {/* Botón de envío */}
+          <Button type='submit' disabled={loading} className='w-full'>
+            {loading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            {loading ? 'Procesando...' : 'Crear Justificación'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/RegistroManualForm.tsx
+++ b/components/admin/RegistroManualForm.tsx
@@ -149,7 +149,7 @@ export function RegistroManualForm({ onSuccess }: RegistroManualFormProps) {
 
       toast({
         title: 'Registro creado exitosamente',
-        description: `Registro manual creado para ${response.empleado.nombreCompleto}. Tipo: ${response.tipo}`,
+        description: `Registro manual creado para ${formData.empleado!.nombreCompleto}. Tipo: ${response.data.tipo}`,
       });
 
       // Reset form

--- a/components/admin/RegistroManualForm.tsx
+++ b/components/admin/RegistroManualForm.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import * as React from 'react';
+import { useState } from 'react';
+import { CalendarIcon, Loader2, Clock } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+
+import { EmployeeSearch } from '@/app/components/shared/employee-search';
+import { EmpleadoSimpleDTO } from '@/app/horarios/asignados/registrar/types';
+import {
+  createRegistroManual,
+  RegistroManualData,
+} from '@/lib/api/registro-manual.api';
+import { useToast } from '@/components/ui/use-toast';
+
+interface RegistroManualFormData {
+  empleado: EmpleadoSimpleDTO | null;
+  fecha: Date | null;
+  hora: string;
+  motivo: string;
+}
+
+interface RegistroManualFormProps {
+  onSuccess?: () => void;
+}
+
+export function RegistroManualForm({ onSuccess }: RegistroManualFormProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formData, setFormData] = useState<RegistroManualFormData>({
+    empleado: null,
+    fecha: null,
+    hora: '',
+    motivo: '',
+  });
+
+  const handleDateChange = (date: Date | undefined) => {
+    setFormData({
+      ...formData,
+      fecha: date || null,
+    });
+
+    // Clear date error
+    if (errors.fecha) {
+      setErrors({
+        ...errors,
+        fecha: '',
+      });
+    }
+  };
+
+  const handleHoraChange = (value: string) => {
+    // Allow only time format (HH:MM)
+    const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
+    const partialTimeRegex = /^([0-1]?[0-9]|2[0-3])?:?[0-5]?[0-9]?$/;
+
+    // Allow partial input while typing
+    if (partialTimeRegex.test(value) || value === '') {
+      setFormData({
+        ...formData,
+        hora: value,
+      });
+
+      // Clear hora error if format is now valid
+      if (errors.hora && (timeRegex.test(value) || value === '')) {
+        setErrors({
+          ...errors,
+          hora: '',
+        });
+      }
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // Validar empleado
+    if (!formData.empleado) {
+      newErrors.empleado = 'Debe seleccionar un empleado';
+    }
+
+    // Validar fecha
+    if (!formData.fecha) {
+      newErrors.fecha = 'La fecha es requerida';
+    } else {
+      // Validar que la fecha no sea futura
+      const today = new Date();
+      today.setHours(23, 59, 59, 999); // Set to end of today
+      if (formData.fecha > today) {
+        newErrors.fecha = 'La fecha no puede ser futura';
+      }
+    }
+
+    // Validar hora
+    if (!formData.hora.trim()) {
+      newErrors.hora = 'La hora es requerida';
+    } else {
+      const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
+      if (!timeRegex.test(formData.hora)) {
+        newErrors.hora = 'Formato de hora inválido (HH:MM)';
+      }
+    }
+
+    // Validar motivo
+    if (!formData.motivo.trim()) {
+      newErrors.motivo = 'El motivo es requerido';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setLoading(true);
+    setErrors({});
+
+    try {
+      // Combine date and time into fechaHora format
+      const fechaStr = format(formData.fecha!, 'yyyy-MM-dd');
+      const fechaHora = `${fechaStr} ${formData.hora}:00`;
+
+      const registroData: RegistroManualData = {
+        empleadoId: formData.empleado!.id,
+        fechaHora,
+        motivo: formData.motivo.trim(),
+      };
+
+      const response = await createRegistroManual(registroData);
+
+      toast({
+        title: 'Registro creado exitosamente',
+        description: `Registro manual creado para ${response.empleado.nombreCompleto}. Tipo: ${response.tipo}`,
+      });
+
+      // Reset form
+      setFormData({
+        empleado: null,
+        fecha: null,
+        hora: '',
+        motivo: '',
+      });
+
+      onSuccess?.();
+    } catch (error: any) {
+      toast({
+        title: 'Error',
+        description:
+          error.message || 'Ocurrió un error al crear el registro manual',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Crear Registro Manual</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className='space-y-6'>
+          {/* Empleado */}
+          <div className='space-y-2'>
+            <Label htmlFor='empleado'>Empleado</Label>
+            <EmployeeSearch
+              value={formData.empleado}
+              onChange={(empleado) => setFormData({ ...formData, empleado })}
+              disabled={loading}
+              placeholder='Buscar empleado por nombre, RFC o CURP...'
+            />
+            {errors.empleado && (
+              <p className='text-sm text-destructive'>{errors.empleado}</p>
+            )}
+          </div>
+
+          {/* Fecha */}
+          <div className='space-y-2'>
+            <Label htmlFor='fecha'>Fecha</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant='outline'
+                  className='w-full justify-start text-left font-normal'
+                  disabled={loading}
+                >
+                  <CalendarIcon className='mr-2 h-4 w-4' />
+                  {formData.fecha ? (
+                    format(formData.fecha, 'PPP', { locale: es })
+                  ) : (
+                    <span>Seleccione fecha</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className='w-auto p-0'>
+                <Calendar
+                  mode='single'
+                  selected={formData.fecha ?? undefined}
+                  onSelect={handleDateChange}
+                  disabled={{ after: new Date() }} // Disable future dates
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+            {errors.fecha && (
+              <p className='text-sm text-destructive'>{errors.fecha}</p>
+            )}
+          </div>
+
+          {/* Hora */}
+          <div className='space-y-2'>
+            <Label htmlFor='hora'>Hora</Label>
+            <div className='relative'>
+              <Clock className='absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground' />
+              <Input
+                id='hora'
+                type='text'
+                placeholder='HH:MM (ej: 08:30)'
+                value={formData.hora}
+                onChange={(e) => handleHoraChange(e.target.value)}
+                disabled={loading}
+                className='pl-10'
+                maxLength={5}
+              />
+            </div>
+            {errors.hora && (
+              <p className='text-sm text-destructive'>{errors.hora}</p>
+            )}
+            <p className='text-xs text-muted-foreground'>
+              Formato de 24 horas (HH:MM). El sistema determinará
+              automáticamente si es entrada o salida.
+            </p>
+          </div>
+
+          {/* Motivo */}
+          <div className='space-y-2'>
+            <Label htmlFor='motivo'>Motivo</Label>
+            <Textarea
+              id='motivo'
+              placeholder='Ingrese el motivo del registro manual (ej: Falla de luz en el área de trabajo)...'
+              value={formData.motivo}
+              onChange={(e) =>
+                setFormData({ ...formData, motivo: e.target.value })
+              }
+              disabled={loading}
+              rows={3}
+            />
+            {errors.motivo && (
+              <p className='text-sm text-destructive'>{errors.motivo}</p>
+            )}
+          </div>
+
+          {/* Botón de envío */}
+          <Button type='submit' disabled={loading} className='w-full'>
+            {loading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            {loading ? 'Creando registro...' : 'Crear Registro Manual'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/adapters/horario-adapter.ts
+++ b/lib/adapters/horario-adapter.ts
@@ -6,13 +6,13 @@ import {
 
 // Mapeo de números a nombres de días
 const DAY_MAP: Record<number, DetalleHorarioDTO['diaSemana']> = {
-  1: 'LUNES',
-  2: 'MARTES',
-  3: 'MIERCOLES',
-  4: 'JUEVES',
-  5: 'VIERNES',
-  6: 'SABADO',
-  7: 'DOMINGO',
+  1: 'DOMINGO',
+  2: 'LUNES',
+  3: 'MARTES',
+  4: 'MIERCOLES',
+  5: 'JUEVES',
+  6: 'VIERNES',
+  7: 'SABADO',
 };
 
 // Tipos del backend (lo que realmente viene de la API)

--- a/lib/api/api-helpers.ts
+++ b/lib/api/api-helpers.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from 'axios';
+
+/**
+ * Extrae un mensaje de error legible desde diferentes tipos de errores de API
+ * @param error - El error capturado (puede ser AxiosError, Error, o unknown)
+ * @param defaultMessage - Mensaje por defecto si no se puede extraer uno específico
+ * @returns Mensaje de error legible para mostrar al usuario
+ */
+export const getApiErrorMessage = (
+  error: unknown,
+  defaultMessage: string = 'Ocurrió un error inesperado.'
+): string => {
+  if (error instanceof AxiosError) {
+    if (error.response?.data?.message) {
+      return error.response.data.message;
+    }
+    if (error.response?.data?.error) {
+      return error.response.data.error;
+    }
+    if (error.request) {
+      return 'Error de red: No se pudo conectar con el servidor.';
+    }
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return defaultMessage;
+};

--- a/lib/api/asistencia.api.ts
+++ b/lib/api/asistencia.api.ts
@@ -1,0 +1,213 @@
+import { apiClient } from '@/lib/apiClient';
+import { getApiErrorMessage } from './api-helpers';
+
+// ============================================================================
+// INTERFACES Y TIPOS CO-UBICADOS
+// ============================================================================
+
+export interface AsistenciaFilters {
+  empleadoId?: number;
+  fechaInicio?: string;
+  fechaFin?: string;
+  estatusId?: number;
+  departamentoId?: number;
+}
+
+export interface AsistenciaRecord {
+  id: number;
+  empleado: {
+    id: number;
+    nombreCompleto: string;
+    numeroEmpleado: string;
+    departamento: {
+      clave: string;
+      nombre: string;
+    };
+  };
+  fecha: string;
+  estatus: {
+    id: number;
+    nombre: string;
+    descripcion: string;
+  };
+  horaEntrada?: string;
+  horaSalida?: string;
+  minutosRetardo?: number;
+  observaciones?: string;
+}
+
+export interface EstatusDisponible {
+  id: number;
+  nombre: string;
+  descripcion: string;
+  color?: string;
+}
+
+export interface EstatusCorrecionData {
+  nuevoEstatusId: number;
+  observaciones?: string;
+  motivo: string;
+}
+
+export interface EstatusCorrecionMasivaData {
+  asistenciaIds: number[];
+  nuevoEstatusId: number;
+  observaciones?: string;
+  motivo: string;
+}
+
+export interface EstatusCorrecionResponse {
+  id: number;
+  mensaje: string;
+  asistenciasAfectadas: number;
+  detalles?: {
+    asistenciaId: number;
+    empleado: string;
+    fecha: string;
+    estatusAnterior: string;
+    estatusNuevo: string;
+  }[];
+}
+
+export interface BusquedaAsistenciasResponse {
+  asistencias: AsistenciaRecord[];
+  total: number;
+  pagina: number;
+  totalPaginas: number;
+}
+
+// ============================================================================
+// FUNCIONES DE API
+// ============================================================================
+
+/**
+ * Busca asistencias según los filtros proporcionados
+ * @param filters - Filtros de búsqueda
+ * @param pagina - Número de página (opcional, default: 1)
+ * @param limite - Límite de resultados por página (opcional, default: 50)
+ * @returns Promise con los resultados de búsqueda
+ */
+export const buscarAsistencias = async (
+  filters: AsistenciaFilters,
+  pagina: number = 1,
+  limite: number = 50
+): Promise<BusquedaAsistenciasResponse> => {
+  try {
+    const params = new URLSearchParams();
+
+    if (filters.empleadoId)
+      params.append('empleadoId', filters.empleadoId.toString());
+    if (filters.fechaInicio) params.append('fechaInicio', filters.fechaInicio);
+    if (filters.fechaFin) params.append('fechaFin', filters.fechaFin);
+    if (filters.estatusId)
+      params.append('estatusId', filters.estatusId.toString());
+    if (filters.departamentoId)
+      params.append('departamentoId', filters.departamentoId.toString());
+
+    params.append('pagina', pagina.toString());
+    params.append('limite', limite.toString());
+
+    const response = await apiClient.get(
+      `/api/asistencias/buscar?${params.toString()}`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al buscar asistencias.'
+      )
+    );
+  }
+};
+
+/**
+ * Obtiene la lista de estatus disponibles para corrección
+ * @returns Promise con la lista de estatus disponibles
+ */
+export const getEstatusDisponibles = async (): Promise<EstatusDisponible[]> => {
+  try {
+    const response = await apiClient.get(
+      '/api/asistencias/estatus/disponibles'
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al obtener los estatus disponibles.'
+      )
+    );
+  }
+};
+
+/**
+ * Corrige el estatus de una asistencia individual
+ * @param id - ID de la asistencia a corregir
+ * @param data - Datos de la corrección
+ * @returns Promise con la respuesta del servidor
+ */
+export const corregirEstatusIndividual = async (
+  id: number,
+  data: EstatusCorrecionData
+): Promise<EstatusCorrecionResponse> => {
+  try {
+    const response = await apiClient.put(
+      `/api/asistencias/${id}/estatus`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al corregir el estatus individual.'
+      )
+    );
+  }
+};
+
+/**
+ * Corrige el estatus de múltiples asistencias de forma masiva
+ * @param data - Datos de la corrección masiva
+ * @returns Promise con la respuesta del servidor
+ */
+export const corregirEstatusMasivo = async (
+  data: EstatusCorrecionMasivaData
+): Promise<EstatusCorrecionResponse> => {
+  try {
+    const response = await apiClient.put(
+      '/api/asistencias/estatus/masivo',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al corregir el estatus masivo.'
+      )
+    );
+  }
+};
+
+/**
+ * Obtiene los detalles de una asistencia específica
+ * @param id - ID de la asistencia
+ * @returns Promise con los detalles de la asistencia
+ */
+export const getAsistenciaById = async (
+  id: number
+): Promise<AsistenciaRecord> => {
+  try {
+    const response = await apiClient.get(`/api/asistencias/${id}`);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al obtener los detalles de la asistencia.'
+      )
+    );
+  }
+};

--- a/lib/api/asistencia.api.ts
+++ b/lib/api/asistencia.api.ts
@@ -69,6 +69,8 @@ export interface EstatusCorrecionResponse {
     estatusAnterior: string;
     estatusNuevo: string;
   }[];
+  warnings?: string[]; // Advertencias del backend
+  success?: boolean;
 }
 
 export interface BusquedaAsistenciasResponse {
@@ -177,19 +179,39 @@ export const corregirEstatusIndividual = async (
   data: EstatusCorrecionData
 ): Promise<EstatusCorrecionResponse> => {
   try {
+    console.log('API: Enviando corrección individual:', { id, data }); // Debug log
     const response = await apiClient.put(
       `/api/asistencias/${id}/estatus`,
       data
     );
+    console.log('API: Respuesta corrección individual:', response.data); // Debug log
+
     // El backend devuelve { success, message, data } donde data contiene la respuesta
-    return response.data.data;
+    const result = response.data.data || response.data;
+
+    return {
+      ...result,
+      warnings:
+        result.warnings || result.advertencias || response.data.warnings || [],
+      success: response.data.success !== false,
+    };
   } catch (error) {
-    throw new Error(
-      getApiErrorMessage(
-        error,
-        'Ocurrió un error inesperado al corregir el estatus individual.'
-      )
-    );
+    // Extraer mensaje específico del backend si está disponible
+    let backendMessage =
+      'Ocurrió un error inesperado al corregir el estatus individual.';
+
+    if (error && typeof error === 'object') {
+      const errorObj = error as any;
+      backendMessage =
+        errorObj.response?.data?.message ||
+        errorObj.response?.data?.mensaje ||
+        errorObj.response?.data?.error ||
+        errorObj.message ||
+        backendMessage;
+    }
+
+    console.error('API: Error en corrección individual:', backendMessage); // Debug log
+    throw new Error(backendMessage);
   }
 };
 
@@ -202,19 +224,39 @@ export const corregirEstatusMasivo = async (
   data: EstatusCorrecionMasivaData
 ): Promise<EstatusCorrecionResponse> => {
   try {
+    console.log('API: Enviando corrección masiva:', data); // Debug log
     const response = await apiClient.put(
       '/api/asistencias/estatus/masivo',
       data
     );
+    console.log('API: Respuesta corrección masiva:', response.data); // Debug log
+
     // El backend devuelve { success, message, data } donde data contiene la respuesta
-    return response.data.data;
+    const result = response.data.data || response.data;
+
+    return {
+      ...result,
+      warnings:
+        result.warnings || result.advertencias || response.data.warnings || [],
+      success: response.data.success !== false,
+    };
   } catch (error) {
-    throw new Error(
-      getApiErrorMessage(
-        error,
-        'Ocurrió un error inesperado al corregir el estatus masivo.'
-      )
-    );
+    // Extraer mensaje específico del backend si está disponible
+    let backendMessage =
+      'Ocurrió un error inesperado al corregir el estatus masivo.';
+
+    if (error && typeof error === 'object') {
+      const errorObj = error as any;
+      backendMessage =
+        errorObj.response?.data?.message ||
+        errorObj.response?.data?.mensaje ||
+        errorObj.response?.data?.error ||
+        errorObj.message ||
+        backendMessage;
+    }
+
+    console.error('API: Error en corrección masiva:', backendMessage); // Debug log
+    throw new Error(backendMessage);
   }
 };
 

--- a/lib/api/justificaciones.api.ts
+++ b/lib/api/justificaciones.api.ts
@@ -1,0 +1,103 @@
+import { apiClient } from '@/lib/apiClient';
+import { getApiErrorMessage } from './api-helpers';
+
+// ============================================================================
+// INTERFACES Y TIPOS CO-UBICADOS
+// ============================================================================
+
+export interface JustificacionIndividualData {
+  empleadoId: number;
+  fechaInicio: string;
+  fechaFin: string;
+  motivo: string;
+}
+
+export interface JustificacionDepartamentalData {
+  departamentoId: number;
+  fecha: string;
+  motivo: string;
+}
+
+export interface JustificacionMasivaData {
+  fecha: string;
+  motivo: string;
+}
+
+export interface JustificacionResponse {
+  id: number;
+  mensaje: string;
+  empleadosAfectados?: number;
+}
+
+// ============================================================================
+// FUNCIONES DE API
+// ============================================================================
+
+/**
+ * Crea una justificación individual para un empleado específico
+ * @param data - Datos de la justificación individual
+ * @returns Promise con la respuesta del servidor
+ */
+export const createJustificacionIndividual = async (
+  data: JustificacionIndividualData
+): Promise<JustificacionResponse> => {
+  try {
+    const response = await apiClient.post(
+      '/api/justificaciones/empleado',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al procesar la justificación individual.'
+      )
+    );
+  }
+};
+
+/**
+ * Crea una justificación departamental para todos los empleados de un departamento
+ * @param data - Datos de la justificación departamental
+ * @returns Promise con la respuesta del servidor
+ */
+export const createJustificacionDepartamental = async (
+  data: JustificacionDepartamentalData
+): Promise<JustificacionResponse> => {
+  try {
+    const response = await apiClient.post(
+      '/api/justificaciones/departamento',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al procesar la justificación departamental.'
+      )
+    );
+  }
+};
+
+/**
+ * Crea una justificación masiva para todos los empleados del sistema
+ * @param data - Datos de la justificación masiva
+ * @returns Promise con la respuesta del servidor
+ */
+export const createJustificacionMasiva = async (
+  data: JustificacionMasivaData
+): Promise<JustificacionResponse> => {
+  try {
+    const response = await apiClient.post('/api/justificaciones/masivo', data);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al procesar la justificación masiva.'
+      )
+    );
+  }
+};

--- a/lib/api/justificaciones.api.ts
+++ b/lib/api/justificaciones.api.ts
@@ -90,9 +90,25 @@ export const createJustificacionMasiva = async (
   data: JustificacionMasivaData
 ): Promise<JustificacionResponse> => {
   try {
+    console.log('API: Enviando justificación masiva:', data); // Debug log
     const response = await apiClient.post('/api/justificaciones/masivo', data);
-    return response.data;
+    console.log('API: Respuesta completa del backend:', response); // Debug log
+    console.log('API: response.data:', response.data); // Debug log
+
+    // El backend puede devolver la respuesta directamente o envuelta
+    const responseData = response.data.data ? response.data : response.data;
+
+    return {
+      id: responseData.id || 0,
+      mensaje:
+        responseData.message || response.data.message || 'Justificación creada',
+      empleadosAfectados:
+        response.data.empleadosJustificados ||
+        response.data.empleadosAfectados ||
+        0,
+    };
   } catch (error) {
+    console.error('API: Error en justificación masiva:', error); // Debug log
     throw new Error(
       getApiErrorMessage(
         error,

--- a/lib/api/registro-manual.api.ts
+++ b/lib/api/registro-manual.api.ts
@@ -7,9 +7,8 @@ import { getApiErrorMessage } from './api-helpers';
 
 export interface RegistroManualData {
   empleadoId: number;
-  fecha: string;
-  hora: string;
-  tipo: 'ENTRADA' | 'SALIDA';
+  fechaHora: string; // Formato: "2025-08-07 08:01:00"
+  motivo: string; // Ej: "Falla de luz en el área de trabajo"
 }
 
 export interface RegistroManualResponse {
@@ -41,8 +40,9 @@ export interface EmpleadoBasico {
 
 /**
  * Crea un registro manual de checada retroactivo
- * @param data - Datos del registro manual
+ * @param data - Datos del registro manual (empleadoId, fechaHora, motivo)
  * @returns Promise con la respuesta del servidor
+ * @note El backend determina automáticamente si es ENTRADA o SALIDA basándose en la hora y horario del empleado
  */
 export const createRegistroManual = async (
   data: RegistroManualData

--- a/lib/api/registro-manual.api.ts
+++ b/lib/api/registro-manual.api.ts
@@ -12,16 +12,16 @@ export interface RegistroManualData {
 }
 
 export interface RegistroManualResponse {
-  id: number;
-  mensaje: string;
-  empleado: {
+  code: string; // "200" o "202" si fue retardo
+  type: string; // "OK"
+  data: {
     id: number;
-    nombreCompleto: string;
-    numeroEmpleado: string;
+    empleadoId: number;
+    fechaHora: string;
+    tipo: string; // "ENTRADA" o "SALIDA"
+    // Otros campos del RegistroDto según el backend
   };
-  fechaHora: string;
-  tipo: string;
-  estatusAsistenciaRecalculado?: string;
+  message: string; // "Registro manual creado exitosamente"
 }
 
 export interface EmpleadoBasico {
@@ -49,6 +49,8 @@ export const createRegistroManual = async (
 ): Promise<RegistroManualResponse> => {
   try {
     const response = await apiClient.post('/api/registros/manual', data);
+    // Según la guía técnica, este endpoint devuelve una estructura diferente
+    // No usa la envoltura estándar { success, message, data }
     return response.data;
   } catch (error) {
     throw new Error(

--- a/lib/api/registro-manual.api.ts
+++ b/lib/api/registro-manual.api.ts
@@ -1,0 +1,79 @@
+import { apiClient } from '@/lib/apiClient';
+import { getApiErrorMessage } from './api-helpers';
+
+// ============================================================================
+// INTERFACES Y TIPOS CO-UBICADOS
+// ============================================================================
+
+export interface RegistroManualData {
+  empleadoId: number;
+  fecha: string;
+  hora: string;
+  tipo: 'ENTRADA' | 'SALIDA';
+}
+
+export interface RegistroManualResponse {
+  id: number;
+  mensaje: string;
+  empleado: {
+    id: number;
+    nombreCompleto: string;
+    numeroEmpleado: string;
+  };
+  fechaHora: string;
+  tipo: string;
+  estatusAsistenciaRecalculado?: string;
+}
+
+export interface EmpleadoBasico {
+  id: number;
+  nombreCompleto: string;
+  numeroEmpleado: string;
+  departamento?: {
+    clave: string;
+    nombre: string;
+  };
+}
+
+// ============================================================================
+// FUNCIONES DE API
+// ============================================================================
+
+/**
+ * Crea un registro manual de checada retroactivo
+ * @param data - Datos del registro manual
+ * @returns Promise con la respuesta del servidor
+ */
+export const createRegistroManual = async (
+  data: RegistroManualData
+): Promise<RegistroManualResponse> => {
+  try {
+    const response = await apiClient.post('/api/registros/manual', data);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al crear el registro manual.'
+      )
+    );
+  }
+};
+
+/**
+ * Obtiene la lista de empleados para selección en el formulario
+ * @returns Promise con la lista de empleados
+ */
+export const getEmpleadosParaRegistro = async (): Promise<EmpleadoBasico[]> => {
+  try {
+    const response = await apiClient.get('/api/empleados');
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Ocurrió un error inesperado al obtener la lista de empleados.'
+      )
+    );
+  }
+};

--- a/lib/api/registro-manual.api.ts
+++ b/lib/api/registro-manual.api.ts
@@ -18,10 +18,13 @@ export interface RegistroManualResponse {
     id: number;
     empleadoId: number;
     fechaHora: string;
-    tipo: string; // "ENTRADA" o "SALIDA"
+    tipoEoS: string; // "E" o "S"
     // Otros campos del RegistroDto según el backend
   };
   message: string; // "Registro manual creado exitosamente"
+  detalles?: string[]; // Mensajes específicos del backend
+  warnings?: string[]; // Advertencias del backend
+  success?: boolean;
 }
 
 export interface EmpleadoBasico {
@@ -48,17 +51,37 @@ export const createRegistroManual = async (
   data: RegistroManualData
 ): Promise<RegistroManualResponse> => {
   try {
+    console.log('API: Enviando registro manual:', data); // Debug log
     const response = await apiClient.post('/api/registros/manual', data);
+    console.log('API: Respuesta registro manual:', response.data); // Debug log
+
     // Según la guía técnica, este endpoint devuelve una estructura diferente
     // No usa la envoltura estándar { success, message, data }
-    return response.data;
+    const result = {
+      ...response.data,
+      detalles: response.data.detalles || response.data.details || [],
+      warnings: response.data.warnings || response.data.advertencias || [],
+      success: response.data.success !== false,
+    };
+
+    return result;
   } catch (error) {
-    throw new Error(
-      getApiErrorMessage(
-        error,
-        'Ocurrió un error inesperado al crear el registro manual.'
-      )
-    );
+    // Extraer mensaje específico del backend si está disponible
+    let backendMessage =
+      'Ocurrió un error inesperado al crear el registro manual.';
+
+    if (error && typeof error === 'object') {
+      const errorObj = error as any;
+      backendMessage =
+        errorObj.response?.data?.message ||
+        errorObj.response?.data?.mensaje ||
+        errorObj.response?.data?.error ||
+        errorObj.message ||
+        backendMessage;
+    }
+
+    console.error('API: Error en registro manual:', backendMessage); // Debug log
+    throw new Error(backendMessage);
   }
 };
 

--- a/lib/api/registros-detalle.api.ts
+++ b/lib/api/registros-detalle.api.ts
@@ -1,0 +1,83 @@
+import { apiClient } from '@/lib/apiClient';
+import { getApiErrorMessage } from './api-helpers';
+
+// ============================================================================
+// INTERFACES Y TIPOS
+// ============================================================================
+
+export interface RegistroDetalle {
+  id: number;
+  empleadoId: number;
+  empleadoNombre: string;
+  tipoRegistroNombre: string;
+  tipoEoS: 'E' | 'S';
+  estatusCalculado: string;
+  fechaHora: string; // Formato "yyyy-MM-dd HH:mm:ss"
+  observaciones: string | null;
+}
+
+export interface RegistrosDetalleResponse {
+  content: RegistroDetalle[];
+  totalPages: number;
+  totalElements: number;
+  number: number; // Página actual (0-indexed)
+}
+
+export interface CorrecionRegistrosRequest {
+  registroIds: number[];
+  nuevoEstatusClave: string;
+  motivo: string;
+}
+
+// ============================================================================
+// FUNCIONES DE API
+// ============================================================================
+
+export const buscarRegistrosDetalle = async (params: {
+  empleadoId?: number | null;
+  departamentoClave?: string | null;
+  desde?: string | null; // "yyyy-MM-dd"
+  hasta?: string | null; // "yyyy-MM-dd"
+  page?: number; // 0-indexed
+  size?: number;
+  sort?: string;
+}): Promise<RegistrosDetalleResponse> => {
+  try {
+    const response = await apiClient.get('/api/registros-detalle', { params });
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(error, 'Error al buscar los registros.')
+    );
+  }
+};
+
+export const corregirEstatusRegistros = async (
+  data: CorrecionRegistrosRequest
+): Promise<RegistroDetalle[]> => {
+  try {
+    const response = await apiClient.put(
+      '/api/registros-detalle/estatus',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(
+        error,
+        'Error al corregir el estatus de los registros.'
+      )
+    );
+  }
+};
+
+export const getClavesEstatus = async (): Promise<string[]> => {
+  try {
+    const response = await apiClient.get('/api/reglas-estatus/claves');
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      getApiErrorMessage(error, 'Error al obtener las claves de estatus.')
+    );
+  }
+};

--- a/lib/hooks/useCorreccionEstatusReducer.ts
+++ b/lib/hooks/useCorreccionEstatusReducer.ts
@@ -1,0 +1,121 @@
+import { useMemo, useState } from 'react';
+import type {
+  AsistenciaFilters,
+  AsistenciaRecord,
+  BusquedaAsistenciasResponse,
+  EstatusDisponible,
+  getEstatusDisponibles,
+} from '@/lib/api/asistencia.api';
+
+// ============================================================================
+// HOOK DE ESTADO: useCorreccionEstatusReducer
+// ============================================================================
+
+type LoadingKeys = 'searching' | 'loadingEstatus' | 'correcting';
+type ErrorKeys = 'estatus' | 'search' | 'correction';
+
+interface PaginationState {
+  currentPage: number;
+  totalPages: number;
+  total: number;
+}
+
+interface CorreccionEstatusState {
+  filters: AsistenciaFilters | {};
+  estatusDisponibles?: EstatusDisponible[];
+  loading: Record<LoadingKeys, boolean>;
+  errors: Partial<Record<ErrorKeys, string>>;
+  searchResults: AsistenciaRecord[];
+  pagination?: PaginationState;
+  selectedIds: number[];
+  modalOpen: boolean;
+}
+
+interface CorreccionEstatusActions {
+  setFilters: (filters: AsistenciaFilters | {}) => void;
+  setEstatusDisponibles: (estatus: EstatusDisponible[]) => void;
+  setLoading: (key: LoadingKeys, value: boolean) => void;
+  setError: (key: ErrorKeys, message: string | undefined) => void;
+  clearErrors: () => void;
+  setSearchResults: (results: BusquedaAsistenciasResponse) => void;
+  setSelection: (ids: number[]) => void;
+  clearSelection: () => void;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export function useCorreccionEstatusReducer(): {
+  state: CorreccionEstatusState;
+  actions: CorreccionEstatusActions;
+} {
+  const [filters, setFilters] = useState<AsistenciaFilters | {}>({});
+  const [estatusDisponibles, setEstatusDisponibles] = useState<
+    EstatusDisponible[] | undefined
+  >(undefined);
+  const [loading, setLoadingState] = useState<Record<LoadingKeys, boolean>>({
+    searching: false,
+    loadingEstatus: false,
+    correcting: false,
+  });
+  const [errors, setErrors] = useState<Partial<Record<ErrorKeys, string>>>({});
+  const [searchResults, setSearchResultsState] = useState<AsistenciaRecord[]>(
+    []
+  );
+  const [pagination, setPagination] = useState<PaginationState | undefined>(
+    undefined
+  );
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+
+  const state: CorreccionEstatusState = useMemo(
+    () => ({
+      filters,
+      estatusDisponibles,
+      loading,
+      errors,
+      searchResults,
+      pagination,
+      selectedIds,
+      modalOpen,
+    }),
+    [
+      filters,
+      estatusDisponibles,
+      loading,
+      errors,
+      searchResults,
+      pagination,
+      selectedIds,
+      modalOpen,
+    ]
+  );
+
+  const actions: CorreccionEstatusActions = useMemo(
+    () => ({
+      setFilters: (newFilters) => {
+        setFilters(newFilters);
+      },
+      setEstatusDisponibles: (estatus) => setEstatusDisponibles(estatus),
+      setLoading: (key, value) =>
+        setLoadingState((prev) => ({ ...prev, [key]: value })),
+      setError: (key, message) =>
+        setErrors((prev) => ({ ...prev, [key]: message })),
+      clearErrors: () => setErrors({}),
+      setSearchResults: (results) => {
+        setSearchResultsState(results.asistencias || []);
+        setPagination({
+          currentPage: results.pagina || 1,
+          totalPages: results.totalPaginas || 0,
+          total: results.total || 0,
+        });
+      },
+      setSelection: (ids) => setSelectedIds(ids),
+      clearSelection: () => setSelectedIds([]),
+      openModal: () => setModalOpen(true),
+      closeModal: () => setModalOpen(false),
+    }),
+    []
+  );
+
+  return { state, actions };
+}


### PR DESCRIPTION
This pull request introduces a new "Herramientas Administrativas" (Administrative Tools) section to the admin area, providing a reorganized interface for several admin tools and improving usability for managing justifications, attendance, and record corrections. It also adds a reusable data table component with multi-selection support and a modal for schedule previews. Additionally, the sidebar navigation is updated to include the new tools section.

Key changes:

**Admin Tools UI Overhaul**

* Added a new page `app/admin/herramientas/page.tsx` that groups and reorganizes administrative tools into three main tabs: Justificaciones, Registros y Checadas, and Asistencias y Procesos. Each tab contains relevant forms/components, improving discoverability and workflow for admins.
* Updated the sidebar navigation (`app/components/sidebar.tsx`) to add a direct link to the new Herramientas Administrativas section, with appropriate icon and keywords for search. [[1]](diffhunk://#diff-f480f895024c083e7fc2357f42ada622c26b11504721d914bdfb9175e3795859R22) [[2]](diffhunk://#diff-f480f895024c083e7fc2357f42ada622c26b11504721d914bdfb9175e3795859L132-R150)

**Reusable Components**

* Introduced a generic `DataTableWithSelection` component (`app/components/shared/data-table-with-selection.tsx`) supporting pagination, sorting, and multi-row selection with checkboxes, to be reused across admin interfaces.
* Added a `SchedulePreviewModal` component (`app/components/shared/SchedulePreviewModal.tsx`) for displaying a modal with a preview of an employee's schedule, including loading and error states.

**Developer Experience**

* Disabled TypeScript's auto-closing tags in VSCode settings to better suit the team's coding preferences. (.vscode/settings.json)